### PR TITLE
refactor: replace UUID4 with MongoDB ObjectId for entity IDs

### DIFF
--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/direction.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/direction.py
@@ -10,7 +10,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Optional, List
-import uuid
+
+from ..utils import generate_id
 
 
 class DirectionStatus(str, Enum):
@@ -39,7 +40,7 @@ class Direction:
     """
 
     # Identifiers
-    direction_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    direction_id: str = field(default_factory=generate_id)
     task_id: str = ""  # Which task this belongs to
     fuzzer: str = ""   # Which fuzzer this direction is for
 
@@ -107,7 +108,7 @@ class Direction:
             created_at = datetime.now()
 
         return cls(
-            direction_id=data.get("direction_id", data.get("_id", str(uuid.uuid4()))),
+            direction_id=data.get("direction_id", data.get("_id", generate_id())),
             task_id=data.get("task_id", ""),
             fuzzer=data.get("fuzzer", ""),
             name=data.get("name", ""),

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/fuzzer.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/fuzzer.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Optional
-import uuid
+
+from ..utils import generate_id
 
 
 class FuzzerStatus(str, Enum):
@@ -29,7 +30,7 @@ class Fuzzer:
     """
 
     # Identifiers
-    fuzzer_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    fuzzer_id: str = field(default_factory=generate_id)
     task_id: str = ""
 
     # Fuzzer info
@@ -68,7 +69,7 @@ class Fuzzer:
     def from_dict(cls, data: dict) -> "Fuzzer":
         """Create Fuzzer from dictionary"""
         return cls(
-            fuzzer_id=data.get("fuzzer_id", data.get("_id", str(uuid.uuid4()))),
+            fuzzer_id=data.get("fuzzer_id", data.get("_id", generate_id())),
             task_id=data.get("task_id", ""),
             fuzzer_name=data.get("fuzzer_name", ""),
             source_path=data.get("source_path"),

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/patch.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/patch.py
@@ -5,7 +5,8 @@ Patch Model - Bug fix patch
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, List
-import uuid
+
+from ..utils import generate_id
 
 
 @dataclass
@@ -21,7 +22,7 @@ class Patch:
     """
 
     # Identifiers
-    patch_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    patch_id: str = field(default_factory=generate_id)
     task_id: str = ""  # Required: which task does this patch belong to
     pov_id: Optional[str] = None  # Optional: which POV is this patch fixing
 
@@ -70,7 +71,7 @@ class Patch:
     def from_dict(cls, data: dict) -> "Patch":
         """Create Patch from dictionary"""
         return cls(
-            patch_id=data.get("patch_id", data.get("_id", str(uuid.uuid4()))),
+            patch_id=data.get("patch_id", data.get("_id", generate_id())),
             task_id=data.get("task_id", ""),
             pov_id=data.get("pov_id"),
             patch_content=data.get("patch_content"),

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/pov.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/pov.py
@@ -5,7 +5,8 @@ POV Model - Proof of Vulnerability
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, List
-import uuid
+
+from ..utils import generate_id
 
 
 @dataclass
@@ -19,7 +20,7 @@ class POV:
     """
 
     # Identifiers
-    pov_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    pov_id: str = field(default_factory=generate_id)
     task_id: str = ""  # Required: which task does this POV belong to
     suspicious_point_id: str = ""  # Which suspicious point this POV is for
     generation_id: str = ""  # Group POVs from same generation (same code, multiple variants)
@@ -92,7 +93,7 @@ class POV:
     def from_dict(cls, data: dict) -> "POV":
         """Create POV from dictionary"""
         return cls(
-            pov_id=data.get("pov_id", data.get("_id", str(uuid.uuid4()))),
+            pov_id=data.get("pov_id", data.get("_id", generate_id())),
             task_id=data.get("task_id", ""),
             suspicious_point_id=data.get("suspicious_point_id", ""),
             generation_id=data.get("generation_id", ""),

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/suspicious_point.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/suspicious_point.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Optional, List, Dict
-import uuid
+
+from ..utils import generate_id
 
 
 class SPStatus(str, Enum):
@@ -50,7 +51,7 @@ class SuspiciousPoint:
     """
 
     # Identifiers
-    suspicious_point_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    suspicious_point_id: str = field(default_factory=generate_id)
     task_id: str = ""  # Which task this belongs to
     function_name: str = ""  # Which function this belongs to
     direction_id: str = ""  # Which direction this belongs to (SP Find v2)
@@ -168,7 +169,7 @@ class SuspiciousPoint:
             sources = [{"harness_name": data.get("harness_name", ""), "sanitizer": data.get("sanitizer", "")}]
 
         return cls(
-            suspicious_point_id=data.get("suspicious_point_id", data.get("_id", str(uuid.uuid4()))),
+            suspicious_point_id=data.get("suspicious_point_id", data.get("_id", generate_id())),
             task_id=data.get("task_id", ""),
             function_name=data.get("function_name", ""),
             sources=sources,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/task.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/task.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Optional, List
-import uuid
+
+from ..utils import generate_id
 
 
 class TaskStatus(str, Enum):
@@ -45,7 +46,7 @@ class Task:
     """
 
     # Core identifiers
-    task_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    task_id: str = field(default_factory=generate_id)
     task_type: JobType = JobType.POV_PATCH
     scan_mode: ScanMode = ScanMode.FULL
     status: TaskStatus = TaskStatus.PENDING

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/utils.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/utils.py
@@ -1,0 +1,20 @@
+"""
+Core Utilities
+
+Centralized utility functions for FuzzingBrain core module.
+"""
+
+from bson import ObjectId
+
+
+def generate_id() -> str:
+    """
+    Generate a unique ID for database entities.
+
+    Uses MongoDB ObjectId which provides:
+    - Zero collision risk (timestamp + machine + process + counter)
+    - Shorter than UUID (24 chars vs 36 chars)
+    - Time-ordered (sortable by creation time)
+    - Native MongoDB optimization
+    """
+    return str(ObjectId())

--- a/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/models.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/models.py
@@ -10,7 +10,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, List
 import hashlib
-import uuid
+
+from ..core.utils import generate_id
 
 
 class FuzzerStatus(str, Enum):
@@ -54,7 +55,7 @@ class CrashRecord:
 
     Used for tracking and deduplication.
     """
-    crash_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    crash_id: str = field(default_factory=generate_id)
     task_id: str = ""
     crash_path: str = ""
     crash_hash: str = ""              # SHA1 for deduplication
@@ -166,7 +167,7 @@ class FuzzerStats:
 @dataclass
 class SeedInfo:
     """Information about a seed added to corpus."""
-    seed_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    seed_id: str = field(default_factory=generate_id)
     seed_path: str = ""
     seed_hash: str = ""
     seed_size: int = 0


### PR DESCRIPTION
## Summary

- Replace UUID4 with MongoDB ObjectId for generating entity IDs in core models
- Add centralized `generate_id()` function in `core/utils.py`

## Changes

| File | Change |
|------|--------|
| `core/utils.py` | New file with `generate_id()` using `bson.ObjectId` |
| `core/models/task.py` | Use `generate_id()` for `task_id` |
| `core/models/pov.py` | Use `generate_id()` for `pov_id` |
| `core/models/patch.py` | Use `generate_id()` for `patch_id` |
| `core/models/fuzzer.py` | Use `generate_id()` for `fuzzer_id` |
| `core/models/suspicious_point.py` | Use `generate_id()` for `suspicious_point_id` |
| `core/models/direction.py` | Use `generate_id()` for `direction_id` |
| `fuzzer/models.py` | Use `generate_id()` for `crash_id`, `seed_id` |

## Benefits

- **Zero collision risk**: ObjectId includes timestamp + machine + process + counter
- **Shorter IDs**: 24 chars vs 36 chars (UUID4)
- **Native MongoDB optimization**: Better index performance for `_id` field
- **Time-ordered**: IDs are sortable by creation time

## Test

```python
from fuzzingbrain.core.utils import generate_id
id1 = generate_id()  # '6984537c952eb56db0a61595'
len(id1)  # 24
```

Closes #61