### PR TITLE
fix: logging, eval infra, and worker timeout issues

### DIFF
--- a/FuzzingBrain-v2/v2/docs/issues-20260206.md
+++ b/FuzzingBrain-v2/v2/docs/issues-20260206.md
@@ -1,0 +1,103 @@
+# Issues Found During Testing - 2026-02-06
+
+Log directory: `/logs/libpng_2c34a678_20260206_063235/`
+
+## Issue 1: Two SeedAgents Generated 0 Seeds
+
+**Files**:
+- `Seed_1_PNG Chunk Parsing an.log` - Seeds Generated: 0
+- `Seed_4_Interlace Handling a.log` - Seeds Generated: 0
+
+**Symptoms**:
+- 12 iterations, 18-19 tool calls
+- Duration: ~120s
+- But no seeds created
+
+**Root Cause**:
+All 5 parallel SeedAgents used the **same** `worker_id` as context key, causing collision:
+- Agent A sets context with `worker_id="worker_xxx"`
+- Agent B overwrites context with same `worker_id`
+- Agent A finishes and clears context
+- Agent C tries to use context → FAILED (already cleared)
+
+**Fix**: Commit `011595224` - Each SeedAgent uses unique `_context_id`:
+- Add `mcp_context_id` property to BaseAgent (default: worker_id)
+- SeedAgent generates `_context_id = f"{worker_id}_{id(self)}"`
+- Use `_context_id` for context key, keeping `worker_id` unchanged
+
+**Status**: FIXED
+
+---
+
+## Issue 2: Budget Exceeded Should Show "Completed" Not "Failed"
+
+**File**: POV agent log
+
+**Current Behavior**:
+```
+│  ❌ FAILED - No crash achieved                                        │
+```
+
+**Expected Behavior**:
+- When budget is exceeded, it's a normal termination
+- Should show "COMPLETED (Budget Limit Reached)" or similar
+- Not a failure
+
+**Fix**: Commit `652d7f650`
+- Add `stop_reason` field to BaseAgent (None, "budget", "timeout", "error")
+- POV agent summary shows:
+  - `✅ SUCCESS - Crash triggered!` - found vulnerability
+  - `⏹️ COMPLETED - No crash found` - normal completion (not a failure)
+  - `⏹️ COMPLETED (Budget Limit Reached)` - budget exceeded
+  - `⏹️ COMPLETED (Time Limit Reached)` - timeout
+  - `❌ FAILED - Error occurred` - only for actual errors
+
+**Status**: FIXED
+
+---
+
+## Issue 3: SPG_0.log Shows No SPs Created, But SPV Agents Exist
+
+**File**: `agent/sp/generate/SPG_0.log`
+
+**Root Cause**:
+- FunctionAnalysisAgent wasn't passing index/target_name/fuzzer/sanitizer to base class
+- This caused fallback to legacy logging path
+- Each function should have its own log file: `SPG_{index}_{function_name}.log`
+
+**Fix**:
+- Updated FunctionAnalysisAgent to pass index, target_name, fuzzer, sanitizer to base class
+- Updated LargeFunctionAnalysisAgent similarly
+- Updated callers in pov_fullscan.py and pov_strategy.py to pass index
+
+**Status**: FIXED
+
+---
+
+## Issue 4: Unknown File `69858baa89fd4d767dfa398e-functioncheck.log`
+
+**File**: `agent/69858baa89fd4d767dfa398e-functioncheck.log`
+
+**Root Cause**:
+- `_write_function_log` and `_write_function_log_v2` methods in pov_strategy.py and pov_fullscan.py
+- These created combined log files using direction_id as filename
+- Redundant with individual agent logs
+
+**Fix**:
+- Removed `_write_function_log` from pov_strategy.py
+- Removed `_write_function_log_v2` from pov_fullscan.py
+- Removed `_direction_log_locks` initialization
+- Added timestamp conflict handling to `get_agent_log_path` in logging.py
+
+**Status**: FIXED
+
+---
+
+## Summary
+
+| # | Issue | Priority | Status |
+|---|-------|----------|--------|
+| 1 | SeedAgent 0 seeds (parallel context collision) | Medium | FIXED (011595224) |
+| 2 | Budget exceeded status | Low | FIXED (652d7f650) |
+| 3 | SPG/SPV inconsistency - wrong log paths | High | FIXED |
+| 4 | Unknown combined log file | Medium | FIXED |

--- a/FuzzingBrain-v2/v2/docs/logging-refactor.md
+++ b/FuzzingBrain-v2/v2/docs/logging-refactor.md
@@ -1,0 +1,336 @@
+# Logging Refactor Plan
+
+## Current Structure (问题)
+
+```
+logs/{project}_{task_id}_{timestamp}/
+├── fuzzingbrain.log                    # 主日志 (太大，所有内容混在一起)
+├── analyzer_3f87c317.log               # Analyzer 日志
+├── celery_worker.log                   # Celery 日志
+├── fuzzer_monitor.log                  # Fuzzer Monitor 日志
+├── error.log                           # 错误日志
+├── build_address.log                   # 构建日志
+├── build_coverage.log
+├── build_introspector.log
+├── worker_3f87c317_libpng_read_fuzzer_address.log   # Worker 日志 (名字太长)
+└── agent/
+    ├── directionplanning_worker_3f87c317_libpng_read_fuzzer_address_20260206_033952.chat.md
+    ├── directionplanning_worker_3f87c317_libpng_read_fuzzer_address_20260206_033952.conversation.json
+    ├── directionplanning_worker_3f87c317_libpng_read_fuzzer_address_20260206_033952.log
+    ├── fullscansp_worker_3f87c317_libpng_read_fuzzer_address_agent_0_20260206_035013.chat.md
+    ├── seed_worker_3f87c317_libpng_read_fuzzer_address_20260206_034321.chat.md
+    └── pov_pov_1_20260206_040322.log
+```
+
+### 问题
+1. **文件名太长** - 包含重复信息 (worker_id, task_id, fuzzer, sanitizer, timestamp)
+2. **agent 日志混乱** - 所有 agent 都在同一目录，难以区分
+3. **Delta vs Full 不一致** - Delta 用 `seed_agent/`，Full 用 `agent/`
+4. **主日志太大** - `fuzzingbrain.log` 包含所有内容
+
+---
+
+## Proposed Structure (新方案)
+
+```
+logs/{project}_{task_id}_{timestamp}/
+├── controller.log                      # 主日志 (Controller/Dispatcher)
+├── celery.log                          # Celery 进程日志 (per-task)
+├── build/
+│   ├── address.log
+│   ├── coverage.log
+│   └── introspector.log
+├── analyzer/
+│   └── server.log
+├── fuzzer/
+│   ├── monitor.log                     # FuzzerMonitor 日志
+│   └── {fuzzer}_{sanitizer}/           # 按 fuzzer+sanitizer 分目录
+│       └── instance.log                # Fuzzer 实例日志
+└── worker/
+    └── {fuzzer}_{sanitizer}/           # 按 fuzzer+sanitizer 分目录
+        ├── worker.log                  # Worker 主日志
+        ├── error.log                   # Worker 错误日志
+        └── agent/
+            ├── direction/
+            │   ├── D_agent.log         # Direction Planning Agent
+            │   └── D_agent.json        # 完整对话记录
+            ├── seed/                   # 编号 + direction_name
+            │   ├── Seed_1_{direction_name}.log
+            │   ├── Seed_1_{direction_name}.json
+            │   ├── Seed_2_{direction_name}.log
+            │   └── Seed_2_{direction_name}.json
+            ├── sp/
+            │   ├── generate/
+            │   │   │ # Delta scan: 单个 agent
+            │   │   ├── SPG_delta.log
+            │   │   └── SPG_delta.json
+            │   │   │ # Full scan: 编号 + direction_name
+            │   │   ├── SPG_1_{direction_name}.log
+            │   │   ├── SPG_1_{direction_name}.json
+            │   │   ├── SPG_2_{direction_name}.log
+            │   │   └── SPG_2_{direction_name}.json
+            │   │
+            │   └── verify/             # 编号 + function_name
+            │       ├── SPV_1_{function_name}.log
+            │       ├── SPV_1_{function_name}.json
+            │       ├── SPV_2_{function_name}.log
+            │       └── SPV_2_{function_name}.json
+            └── pov/                    # 编号 + function_name
+                ├── POV_1_{function_name}.log
+                ├── POV_1_{function_name}.json
+                ├── POV_2_{function_name}.log
+                └── POV_2_{function_name}.json
+```
+
+### 改进
+1. **简化文件名** - 用序号代替长字符串
+2. **按类型分目录** - build/, analyzer/, fuzzer/, worker/
+3. **按 fuzzer+sanitizer 分子目录** - 清晰隔离
+4. **agent 按类型分目录** - direction/, seed/, sp/, pov/
+5. **统一命名** - 序号 + 扩展名
+
+---
+
+## 文件命名规则
+
+| Agent 类型 | 当前名称 | 新名称 |
+|------------|---------|--------|
+| Direction | `directionplanning_worker_xxx_timestamp.log` | `direction/D_agent.{log,json}` |
+| Seed | `seed_worker_xxx_timestamp.log` | `seed/Seed_1_{direction_name}.{log,json}` |
+| SP Generate (Delta) | `suspiciouspoint_worker_xxx_timestamp.log` | `sp/generate/SPG_delta.{log,json}` |
+| SP Generate (Full) | `fullscansp_worker_xxx_agent_0_timestamp.log` | `sp/generate/SPG_1_{direction_name}.{log,json}` |
+| SP Verify | `suspiciouspoint_verify_1_timestamp.log` | `sp/verify/SPV_1_{function_name}.{log,json}` |
+| POV | `pov_pov_1_timestamp.log` | `pov/POV_1_{function_name}.{log,json}` |
+
+| 其他日志 | 当前名称 | 新名称 |
+|---------|---------|--------|
+| 主日志 | `fuzzingbrain.log` | `controller.log` |
+| Celery | `celery_worker.log` | `celery.log` (根目录) |
+| Worker | `worker_xxx_fuzzer_sanitizer.log` | `worker/{fuzzer}_{san}/worker.log` |
+| Worker 错误 | `error.log` (根目录) | `worker/{fuzzer}_{san}/error.log` |
+| Build | `build_address.log` | `build/address.log` |
+| Analyzer | `analyzer_xxx.log` | `analyzer/server.log` |
+| Fuzzer Monitor | `fuzzer_monitor.log` | `fuzzer/monitor.log` |
+
+### 日志文件规则
+- `.json` = 完整对话记录，不可 truncate
+- `.log` = 可读日志，可 truncate
+- 单文件最大 **50MB**（超过后 rotate）
+
+### 日志级别配置
+
+| 文件 | 级别 | 说明 |
+|-----|------|-----|
+| `worker.log` | INFO | 主要事件 |
+| `agent/*.log` | DEBUG | 详细执行过程 |
+| `error.log` | WARNING+ | 警告和错误 |
+| `controller.log` | INFO | 主控制流程 |
+
+### 时间戳格式
+
+统一使用本地时间：`2026-02-06 03:39:52.490`
+
+### 文件名 vs 文件内容
+
+| | 文件名 | 文件内容 (Header/JSON) |
+|--|--------|----------------------|
+| ID | ❌ 不用 | ✅ 必须完整 |
+| direction_name | 截断 (≤20字符) | ✅ 完整 |
+| function_name | 截断 (≤20字符) | ✅ 完整 |
+| task_id | ❌ 不用 | ✅ 必须 |
+| worker_id | ❌ 不用 | ✅ 必须 |
+| sp_id | ❌ 不用 | ✅ 必须 |
+| direction_id | ❌ 不用 | ✅ 必须 |
+
+**原则：文件名简洁可读，文件内容完整可追溯**
+
+---
+
+## 日志内容规范
+
+### Agent 名称缩写
+
+日志中统一使用缩写，避免冗长全称：
+
+| 全称 | 缩写 | 日志前缀 | 文件名 |
+|-----|------|---------|--------|
+| DirectionPlanningAgent | Direction | `[Direction]` | `D_agent.log` |
+| SeedAgent | Seed | `[Seed-1]` | `Seed_1_{direction_name}.log` |
+| SuspiciousPointAgent (Delta) | SPG-Delta | `[SPG-Delta]` | `SPG_delta.log` |
+| FullscanSPAgent | SPG | `[SPG-1]` | `SPG_1_{direction_name}.log` |
+| SPVerifyAgent | SPV | `[SPV-1]` | `SPV_1_{function_name}.log` |
+| POVAgent | POV | `[POV-1]` | `POV_1_{function_name}.log` |
+
+### Worker 日志 vs Agent 日志分工
+
+避免重复记录，明确分工：
+
+| 日志 | 记录内容 | 不记录 |
+|-----|---------|--------|
+| `worker.log` | Worker 生命周期、策略选择、Agent 创建/结束、关键事件摘要 | Agent 详细 tool calls、LLM 对话 |
+| `agent/*.log` | Agent 详细执行、tool calls、LLM 对话、迭代过程 | Worker 级别事件 |
+
+### Agent 编号规则
+
+使用自然编号，不用 ID：
+
+| Agent 类型 | 编号规则 | 示例 |
+|-----------|---------|------|
+| Direction | 单个，无编号 | `[Direction]` |
+| Seed | 按 direction 顺序 | `[Seed-1]`, `[Seed-2]` |
+| SPG-Full | 按 direction 顺序 | `[SPG-1]`, `[SPG-2]` |
+| SPG-Delta | 单个，无编号 | `[SPG-Delta]` |
+| SPV | 按 SP 顺序 | `[SPV-1]`, `[SPV-2]` |
+| POV | 按 SP 顺序 + 重试次数 | `[POV-1]`, `[POV-2]` |
+
+### 文件名截断规则
+
+`{direction_name}` 和 `{function_name}` 最多 20 字符，超出截断：
+
+```python
+def truncate_name(name: str, max_len: int = 20) -> str:
+    if len(name) <= max_len:
+        return name
+    return name[:max_len]
+```
+
+示例：
+- `png_chunk_parsing` → `png_chunk_parsing` (不变)
+- `very_long_direction_name_for_analysis` → `very_long_direction_`
+
+### 日志格式规范
+
+```
+# Worker 日志示例 (简洁摘要)
+2026-02-06 03:39:52 | INFO  | [Worker] Strategy: POV-Full
+2026-02-06 03:39:52 | INFO  | [Worker] Direction started
+2026-02-06 03:40:15 | INFO  | [Worker] Direction done → 5 directions
+2026-02-06 03:40:15 | INFO  | [Worker] Seed-1 started (png_chunk_parsing)
+2026-02-06 03:40:30 | INFO  | [Worker] Seed-1 done → 3 seeds
+2026-02-06 03:40:30 | INFO  | [Worker] SPG-1 started (png_chunk_parsing)
+2026-02-06 03:41:00 | INFO  | [Worker] SPG-1 done → 2 SPs
+2026-02-06 03:41:00 | INFO  | [Worker] SPV pipeline: 2 agents started
+2026-02-06 03:42:00 | INFO  | [Worker] SPV-1 done → verified
+2026-02-06 03:42:00 | INFO  | [Worker] POV-1 started
+```
+
+```
+# Agent 日志示例 (详细执行)
+2026-02-06 03:39:52 | INFO  | [SPG-1] === Iteration 1/50 ===
+2026-02-06 03:39:52 | DEBUG | [SPG-1] LLM: claude-opus-4-5
+2026-02-06 03:39:55 | INFO  | [SPG-1] Tool: get_function_source(png_read_IDAT_data)
+2026-02-06 03:39:55 | DEBUG | [SPG-1] Result: 4236 lines
+2026-02-06 03:39:56 | INFO  | [SPG-1] Tool: create_suspicious_point(...)
+2026-02-06 03:39:56 | INFO  | [SPG-1] SP created: integer-truncation @ png_read_IDAT_data
+```
+
+---
+
+## 日志文件头部元信息
+
+每个日志文件开头必须包含元信息 header，格式保持现有风格：
+
+### Agent 日志 Header
+```
+╔══════════════════════════════════════════════════════════════════╗
+║                     FuzzingBrain Agent v2.0                      ║
+╚══════════════════════════════════════════════════════════════════╝
+
+┌──────────────────────────────────────────────────────────────────┐
+│                      {Agent Type} Agent                          │
+├──────────────────────────────────────────────────────────────────┤
+│  Scan Mode:    {full/delta}                                      │
+│  Fuzzer:       {fuzzer_name}                                     │
+│  Sanitizer:    {sanitizer}                                       │
+│  Worker ID:    {worker_id}                                       │
+│  Task ID:      {task_id}                                         │
+├──────────────────────────────────────────────────────────────────┤
+│  Target:       {direction_name / function_name / sp_id}          │
+│  Purpose:      {agent 目标描述}                                   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 必需的元信息字段
+
+| Agent 类型 | 必需字段 |
+|-----------|---------|
+| Direction | scan_mode, fuzzer, sanitizer, worker_id, task_id |
+| Seed | + direction_id, direction_name |
+| SP Generate (Delta) | + changed_functions (列表) |
+| SP Generate (Full) | + direction_id, direction_name, core_functions |
+| SP Verify | + sp_id, function_name, file_path |
+| POV | + sp_id, vuln_type, function_name |
+
+### Worker 日志 Header
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                      WORKER ASSIGNMENT                           │
+├──────────────────────────────────────────────────────────────────┤
+│  Worker ID:   {worker_id}                                        │
+│  Task ID:     {task_id}                                          │
+│  Project:     {project_name}                                     │
+│  Fuzzer:      {fuzzer}                                           │
+│  Sanitizer:   {sanitizer}                                        │
+│  Job Type:    {pov/harness}                                      │
+│  Scan Mode:   {full/delta}                                       │
+│  Start Time:  {timestamp}                                        │
+│  Workspace:   {workspace_path}                                   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 实现步骤
+
+- [x] 1. 修改 `core/logging.py` - 新的目录结构创建、Loguru 配置、50MB rotation
+- [x] 2. 修改 `agents/base.py` - Agent 日志路径生成、添加 `index` 参数
+- [x] 3. 修改各 Agent 子类 - 添加 `agent_type` 属性
+- [x] 4. 修改 `worker/pipeline.py` - 传递 index/target_name 给 Agent
+- [x] 5. 修改 `worker/strategies/*.py` - 传递 index/target_name 给 Agent
+- [x] 6. 修改 `analyzer/builder.py` - Build 日志路径 (`build/{sanitizer}.log`)
+- [x] 7. 修改 `fuzzer/monitor.py` - FuzzerMonitor 日志路径 (`fuzzer/monitor.log`)
+- [ ] 8. 统一所有模块使用 Loguru（替换 logging 模块）
+
+---
+
+## MCP Tool Call 记录
+
+### 现状
+`.conversation.json` 已经包含完整的 tool call 记录：
+
+```json
+{
+  "role": "assistant",
+  "content": "...",
+  "tool_calls": [
+    {
+      "id": "toolu_xxx",
+      "type": "function",
+      "function": {
+        "name": "get_function_source",
+        "arguments": "{\"function_name\": \"png_read_IDAT_data\"}"
+      }
+    }
+  ]
+},
+{
+  "role": "tool",
+  "tool_call_id": "toolu_xxx",
+  "content": "{\"success\":true,...}"
+}
+```
+
+### 结论：不需要额外记录
+
+原因：
+1. **已有完整记录** - conversation.json 按 Agent 为单位记录了所有 tool calls
+2. **可追溯** - 从 JSON 中可以重放整个 Agent 的执行过程
+3. **避免冗余** - 单独记录会造成重复
+
+如需统计分析（tool call 次数、耗时等），可从 conversation.json 提取。
+
+---
+
+## 讨论
+
+（暂无其他讨论）

--- a/FuzzingBrain-v2/v2/docs/logging-refactor.md
+++ b/FuzzingBrain-v2/v2/docs/logging-refactor.md
@@ -289,7 +289,7 @@ def truncate_name(name: str, max_len: int = 20) -> str:
 - [x] 5. 修改 `worker/strategies/*.py` - 传递 index/target_name 给 Agent
 - [x] 6. 修改 `analyzer/builder.py` - Build 日志路径 (`build/{sanitizer}.log`)
 - [x] 7. 修改 `fuzzer/monitor.py` - FuzzerMonitor 日志路径 (`fuzzer/monitor.log`)
-- [ ] 8. 统一所有模块使用 Loguru（替换 logging 模块）
+- [x] 8. 统一所有模块使用 Loguru（Celery 日志通过 InterceptHandler 重定向）
 
 ---
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
@@ -177,6 +177,16 @@ class BaseAgent(ABC):
         return True
 
     @property
+    def mcp_context_id(self) -> str:
+        """ID used for MCP tool context lookup.
+
+        Default is worker_id. Override in agents that run in parallel
+        (like SeedAgent) to use a unique per-instance ID to prevent
+        context collision.
+        """
+        return self.worker_id
+
+    @property
     @abstractmethod
     def system_prompt(self) -> str:
         """System prompt for the agent."""
@@ -1061,7 +1071,7 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
             # Pass worker_id so POV tools can find the right context
             mcp_server = create_isolated_mcp_server(
                 agent_id=agent_id,
-                worker_id=self.worker_id,  # Bind worker_id for POV/seed context lookup
+                worker_id=self.mcp_context_id,  # Bind context_id for POV/seed context lookup
                 include_pov_tools=self.include_pov_tools,  # Only POVAgent needs POV tools
                 include_seed_tools=self.include_seed_tools,  # Only SeedAgent needs seed tools
                 include_sp_tools=self.include_sp_tools,  # DirectionPlanningAgent doesn't need SP tools

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
@@ -120,6 +120,10 @@ class BaseAgent(ABC):
         self.start_time: Optional[datetime] = None
         self.end_time: Optional[datetime] = None
 
+        # Stop reason for graceful termination tracking
+        # None = normal completion, "budget" = budget exceeded, "timeout" = time limit
+        self.stop_reason: Optional[str] = None
+
         # Agent-specific logger
         self._agent_logger = None
         self._log_file: Optional[Path] = None
@@ -939,6 +943,7 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
 
                 if isinstance(e, BudgetExceededError):
                     self._log(f"Budget limit exceeded: {e}", level="WARNING")
+                    self.stop_reason = "budget"
                     raise
                 import traceback
 
@@ -1105,11 +1110,19 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
                     result = await self._run_agent_loop(client, initial_message)
 
         except Exception as e:
-            self._log(f"Agent run failed: {e}", level="ERROR")
-            import traceback
+            # Check if it's a budget/resource limit (not a real failure)
+            from ..eval import BudgetExceededError
 
-            self._log(f"Traceback:\n{traceback.format_exc()}", level="ERROR")
-            result = f"Agent failed: {e}"
+            if isinstance(e, BudgetExceededError):
+                self._log(f"Agent stopped: {e}", level="INFO")
+                result = f"Agent stopped (budget limit): {e}"
+            else:
+                self._log(f"Agent run failed: {e}", level="ERROR")
+                import traceback
+
+                self._log(f"Traceback:\n{traceback.format_exc()}", level="ERROR")
+                self.stop_reason = "error"  # Mark as actual failure
+                result = f"Agent failed: {e}"
 
         self.end_time = datetime.now()
         duration = (self.end_time - self.start_time).total_seconds()

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
@@ -16,7 +16,7 @@ from loguru import logger
 
 from ..llms import LLMClient, ModelInfo
 from ..tools.mcp_factory import create_isolated_mcp_server
-from ..core.logging import get_agent_banner_and_header
+from ..core.logging import get_agent_banner_and_header, get_agent_log_path
 
 # Lazy import for reporter to avoid circular imports
 _reporter_getter = None
@@ -68,6 +68,11 @@ class BaseAgent(ABC):
         task_id: str = "",
         worker_id: str = "",
         log_dir: Optional[Path] = None,
+        # New: for numbered log files
+        index: int = 0,
+        target_name: str = "",
+        fuzzer: str = "",
+        sanitizer: str = "",
     ):
         """
         Initialize agent.
@@ -81,6 +86,10 @@ class BaseAgent(ABC):
             task_id: Task ID for logging context
             worker_id: Worker ID for logging context
             log_dir: Directory for log files
+            index: Agent index for numbered log files (1-based)
+            target_name: Target name (direction_name or function_name) for log filename
+            fuzzer: Fuzzer name for log path
+            sanitizer: Sanitizer name for log path
         """
         self.llm_client = llm_client or LLMClient()
         self.model = model
@@ -94,6 +103,10 @@ class BaseAgent(ABC):
         self.task_id = task_id
         self.worker_id = worker_id
         self.log_dir = log_dir
+        self.index = index
+        self.target_name = target_name
+        self.fuzzer = fuzzer
+        self.sanitizer = sanitizer
 
         # Conversation history
         self.messages: List[Dict[str, str]] = []
@@ -110,12 +123,25 @@ class BaseAgent(ABC):
         # Agent-specific logger
         self._agent_logger = None
         self._log_file: Optional[Path] = None
-        self._chat_log_file: Optional[Path] = None
 
     @property
     def agent_name(self) -> str:
         """Get agent name for logging."""
         return self.__class__.__name__
+
+    @property
+    def agent_type(self) -> str:
+        """
+        Get agent type for log path generation.
+
+        Override in subclasses. Valid values: "direction", "seed", "spg", "spv", "pov"
+        """
+        return "direction"  # Default, subclasses should override
+
+    @property
+    def is_delta(self) -> bool:
+        """Whether this is a delta scan agent (for SPG log naming)."""
+        return False
 
     @property
     def include_pov_tools(self) -> bool:
@@ -363,6 +389,85 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
 
     def _setup_logging(self) -> None:
         """Set up agent-specific logging."""
+        # Try new structured path first (if fuzzer/sanitizer available)
+        if self.fuzzer and self.sanitizer:
+            log_path = get_agent_log_path(
+                agent_type=self.agent_type,
+                fuzzer=self.fuzzer,
+                sanitizer=self.sanitizer,
+                index=self.index,
+                target_name=self.target_name,
+                is_delta=self.is_delta,
+            )
+            if log_path:
+                self._log_file = Path(str(log_path) + ".log")
+            else:
+                # Fallback to legacy path if get_agent_log_path returns None
+                self._setup_logging_legacy()
+                return
+        elif self.log_dir:
+            # Fallback to legacy path
+            self._setup_logging_legacy()
+            return
+        else:
+            return
+
+        # Create unique instance ID for this agent (for log filtering)
+        self._agent_instance_id = f"{self.agent_name}_{self.worker_id}_{id(self)}"
+
+        # Write banner to log file first
+        metadata = self._get_agent_metadata()
+        banner = get_agent_banner_and_header(metadata)
+        self._log_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self._log_file, "w", encoding="utf-8") as f:
+            f.write(banner)
+            f.write("\n")
+
+        # Add file handler with agent-specific filter
+        self._agent_logger = logger.bind(
+            agent=self.agent_name,
+            agent_instance_id=self._agent_instance_id,
+            task_id=self.task_id,
+            worker_id=self.worker_id,
+            fuzzer=self.fuzzer,
+            sanitizer=self.sanitizer,
+        )
+
+        # Build format string - simplified with agent prefix
+        # Format: timestamp | level | [Agent-N] | message
+        agent_prefix = self._get_log_prefix()
+        log_format = f"{{time:YYYY-MM-DD HH:mm:ss.SSS}} | {{level: <8}} | {agent_prefix} | {{message}}"
+
+        # Add file sink for this agent - use instance ID for filtering (append mode)
+        instance_id = self._agent_instance_id  # Capture for closure
+        logger.add(
+            self._log_file,
+            level="DEBUG",
+            format=log_format,
+            filter=lambda record: (
+                record["extra"].get("agent_instance_id") == instance_id
+            ),
+            encoding="utf-8",
+            rotation="50 MB",
+            mode="a",  # Append after banner
+        )
+
+        self._log("Logging initialized", level="INFO")
+        self._log(f"Log file: {self._log_file}", level="INFO")
+
+    def _get_log_prefix(self) -> str:
+        """Get the log prefix for this agent (e.g., [SPG-1], [Direction])."""
+        prefix_map = {
+            "direction": "Direction",
+            "seed": f"Seed-{self.index}",
+            "spg": "SPG-Delta" if self.is_delta else f"SPG-{self.index}",
+            "spv": f"SPV-{self.index}",
+            "pov": f"POV-{self.index}",
+        }
+        return f"[{prefix_map.get(self.agent_type, self.agent_name)}]"
+
+    def _setup_logging_legacy(self) -> None:
+        """Legacy logging setup for backward compatibility."""
         if not self.log_dir:
             return
 
@@ -404,7 +509,6 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
         )
 
         # Build format string with context info
-        # Format: timestamp | level | agent | task_id | worker_id | fuzzer | sanitizer | message
         format_parts = [
             "{time:YYYY-MM-DD HH:mm:ss.SSS}",
             "{level: <8}",
@@ -421,8 +525,8 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
         format_parts.append("{message}")
         log_format = " | ".join(format_parts)
 
-        # Add file sink for this agent - use instance ID for filtering (append mode)
-        instance_id = self._agent_instance_id  # Capture for closure
+        # Add file sink for this agent
+        instance_id = self._agent_instance_id
         logger.add(
             self._log_file,
             level="DEBUG",
@@ -431,14 +535,10 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
                 record["extra"].get("agent_instance_id") == instance_id
             ),
             encoding="utf-8",
-            mode="a",  # Append after banner
+            mode="a",
         )
 
-        # Create chat log file for detailed conversation tracking
-        self._chat_log_file = self._log_file.with_suffix(".chat.md")
-        self._init_chat_log()
-
-        self._log("Logging initialized", level="INFO")
+        self._log("Logging initialized (legacy)", level="INFO")
         self._log(f"Log file: {self._log_file}", level="INFO")
 
     def _log(self, message: str, level: str = "DEBUG") -> None:
@@ -500,32 +600,6 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
         except Exception as e:
             self._log(f"Failed to write summary table: {e}", level="ERROR")
 
-    def _init_chat_log(self) -> None:
-        """Initialize the detailed chat log file with markdown header."""
-        if not hasattr(self, "_chat_log_file") or not self._chat_log_file:
-            return
-        try:
-            # Get fuzzer and sanitizer from subclass if available
-            fuzzer = getattr(self, "fuzzer", "") or ""
-            sanitizer = getattr(self, "sanitizer", "") or ""
-
-            with open(self._chat_log_file, "w", encoding="utf-8") as f:
-                f.write("# Agent Chat Log\n\n")
-                f.write(f"- **Agent**: {self.agent_name}\n")
-                f.write(f"- **Task ID**: {self.task_id}\n")
-                f.write(f"- **Worker ID**: {self.worker_id}\n")
-                if fuzzer:
-                    f.write(f"- **Fuzzer**: {fuzzer}\n")
-                if sanitizer:
-                    f.write(f"- **Sanitizer**: {sanitizer}\n")
-                f.write(f"- **Start Time**: {datetime.now().isoformat()}\n")
-                f.write(
-                    f"- **Model**: {self.model.id if hasattr(self.model, 'id') else (self.model or 'default')}\n"
-                )
-                f.write(f"\n{'=' * 80}\n\n")
-        except Exception as e:
-            self._log(f"Failed to init chat log: {e}", level="ERROR")
-
     def _log_chat_message(
         self,
         role: str,
@@ -537,7 +611,7 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
         tool_success: Optional[bool] = None,
     ) -> None:
         """
-        Log a chat message with clear visual separation.
+        Report chat message to eval system.
 
         Args:
             role: Message role (system, user, assistant, tool)
@@ -559,83 +633,6 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
                 tool_name=tool_name,
                 tool_success=tool_success,
             )
-
-        if not hasattr(self, "_chat_log_file") or not self._chat_log_file:
-            return
-
-        try:
-            with open(self._chat_log_file, "a", encoding="utf-8") as f:
-                timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
-
-                # Role-specific formatting with clear visual separators
-                if role == "system":
-                    f.write("## 📋 SYSTEM PROMPT\n")
-                    f.write(f"*[{timestamp}]*\n\n")
-                    f.write(f"```\n{content}\n```\n\n")
-                    f.write(f"{'─' * 80}\n\n")
-
-                elif role == "user":
-                    f.write(f"## 👤 USER (Iteration {iteration})\n")
-                    f.write(f"*[{timestamp}]*\n\n")
-                    f.write(f"{content}\n\n")
-                    f.write(f"{'─' * 80}\n\n")
-
-                elif role == "assistant":
-                    f.write(f"## 🤖 ASSISTANT (Iteration {iteration})\n")
-                    f.write(f"*[{timestamp}]*\n\n")
-                    if content:
-                        f.write(f"{content}\n\n")
-                    if tool_calls:
-                        f.write("### Tool Calls:\n")
-                        for tc in tool_calls:
-                            func_name = tc.get("function", {}).get("name", "unknown")
-                            func_args = tc.get("function", {}).get("arguments", "{}")
-                            tc_id = tc.get("id", "")
-                            f.write(f"- **{func_name}** (id: `{tc_id}`)\n")
-                            f.write(f"  ```json\n  {func_args}\n  ```\n")
-                        f.write("\n")
-                    f.write(f"{'─' * 80}\n\n")
-
-                elif role == "tool":
-                    f.write("## 🔧 TOOL RESULT\n")
-                    f.write(f"*[{timestamp}]* Tool Call ID: `{tool_call_id}`\n\n")
-                    # Truncate very long tool results for readability
-                    if len(content) > 5000:
-                        f.write(
-                            f"```\n{content[:5000]}\n... (truncated, {len(content)} total chars)\n```\n\n"
-                        )
-                    else:
-                        f.write(f"```\n{content}\n```\n\n")
-                    f.write(f"{'─' * 80}\n\n")
-
-        except Exception as e:
-            self._log(f"Failed to log chat message: {e}", level="ERROR")
-
-    def _finalize_chat_log(self, final_response: str) -> None:
-        """Finalize the chat log with summary statistics."""
-        if not hasattr(self, "_chat_log_file") or not self._chat_log_file:
-            return
-
-        try:
-            duration = (
-                (self.end_time - self.start_time).total_seconds()
-                if self.start_time and self.end_time
-                else 0
-            )
-
-            with open(self._chat_log_file, "a", encoding="utf-8") as f:
-                f.write(f"\n{'=' * 80}\n")
-                f.write("# SUMMARY\n\n")
-                f.write(
-                    f"- **End Time**: {self.end_time.isoformat() if self.end_time else 'N/A'}\n"
-                )
-                f.write(f"- **Duration**: {duration:.2f} seconds\n")
-                f.write(f"- **Total Iterations**: {self.total_iterations}\n")
-                f.write(f"- **Total Tool Calls**: {self.total_tool_calls}\n")
-                f.write(f"- **Total Messages**: {len(self.messages)}\n\n")
-                f.write(f"## Final Response:\n\n{final_response}\n")
-        except Exception as e:
-            self._log(f"Failed to finalize chat log: {e}", level="ERROR")
 
     def _log_conversation(self) -> None:
         """Log the full conversation history to file."""
@@ -1114,11 +1111,8 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
         # Write summary table to log
         self._write_summary_table()
 
-        # Note: conversation log is saved incrementally after each iteration
+        # Note: conversation log (.json) is saved incrementally after each iteration
         # No need to save again here
-
-        # Finalize chat log (markdown format with summary)
-        self._finalize_chat_log(result)
 
         return result
 
@@ -1152,8 +1146,7 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
 
         if self._log_file:
             stats["log_file"] = str(self._log_file)
-
-        if self._chat_log_file:
-            stats["chat_log_file"] = str(self._chat_log_file)
+            # JSON conversation file is same path with .json extension
+            stats["conversation_file"] = str(self._log_file.with_suffix(".json"))
 
         return stats

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/direction_planning_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/direction_planning_agent.py
@@ -32,6 +32,11 @@ class DirectionPlanningAgent(BaseAgent):
     # Medium temperature for strategic planning
     default_temperature: float = 0.5
 
+    @property
+    def agent_type(self) -> str:
+        """Direction planning agent type."""
+        return "direction"
+
     def __init__(
         self,
         fuzzer: str = "",
@@ -68,10 +73,9 @@ class DirectionPlanningAgent(BaseAgent):
             task_id=task_id,
             worker_id=worker_id,
             log_dir=log_dir,
+            fuzzer=fuzzer,
+            sanitizer=sanitizer,
         )
-
-        self.fuzzer = fuzzer
-        self.sanitizer = sanitizer
         self.max_directions = max_directions
 
         # Track created directions

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/fullscan_sp_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/fullscan_sp_agent.py
@@ -40,6 +40,11 @@ class FullscanSPAgent(BaseAgent):
         "low": 0,
     }
 
+    @property
+    def agent_type(self) -> str:
+        """SPG for Full-scan mode."""
+        return "spg"
+
     def __init__(
         self,
         fuzzer: str = "",
@@ -58,6 +63,8 @@ class FullscanSPAgent(BaseAgent):
         task_id: str = "",
         worker_id: str = "",
         log_dir: Optional[Path] = None,
+        # New: for numbered log files
+        index: int = 0,
     ):
         """
         Initialize Full-scan SP Find Agent.
@@ -79,6 +86,7 @@ class FullscanSPAgent(BaseAgent):
             task_id: Task ID
             worker_id: Worker ID
             log_dir: Log directory
+            index: Agent index for numbered log files
         """
         super().__init__(
             llm_client=llm_client,
@@ -88,10 +96,12 @@ class FullscanSPAgent(BaseAgent):
             task_id=task_id,
             worker_id=worker_id,
             log_dir=log_dir,
+            index=index,
+            target_name=direction_name,
+            fuzzer=fuzzer,
+            sanitizer=sanitizer,
         )
 
-        self.fuzzer = fuzzer
-        self.sanitizer = sanitizer
         self.direction_name = direction_name
         self.direction_id = direction_id
         self.risk_level = risk_level.lower()

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/function_analysis_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/function_analysis_agent.py
@@ -64,6 +64,8 @@ class FunctionAnalysisAgent(BaseAgent):
         task_id: str = "",
         worker_id: str = "",
         log_dir: Optional[Path] = None,
+        # Log file naming
+        index: int = 0,  # Agent index for numbered log files
     ):
         """
         Initialize Function Analysis Agent.
@@ -96,6 +98,10 @@ class FunctionAnalysisAgent(BaseAgent):
             task_id=task_id,
             worker_id=worker_id,
             log_dir=log_dir,
+            index=index,
+            target_name=function_name,  # Use function name for log file naming
+            fuzzer=fuzzer,
+            sanitizer=sanitizer,
         )
 
         self.function_name = function_name
@@ -442,6 +448,7 @@ class LargeFunctionAnalysisAgent(FunctionAnalysisAgent):
         task_id: str = "",
         worker_id: str = "",
         log_dir: Optional[Path] = None,
+        index: int = 0,  # Agent index for numbered log files
         # Large function specific
         use_sliding_window: bool = True,
         window_size: int = 100,  # Lines per window
@@ -465,6 +472,7 @@ class LargeFunctionAnalysisAgent(FunctionAnalysisAgent):
             task_id=task_id,
             worker_id=worker_id,
             log_dir=log_dir,
+            index=index,
         )
 
         self.use_sliding_window = use_sliding_window

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/function_analysis_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/function_analysis_agent.py
@@ -33,6 +33,11 @@ class FunctionAnalysisAgent(BaseAgent):
     # Lower temperature for focused analysis
     default_temperature: float = 0.5
 
+    @property
+    def agent_type(self) -> str:
+        """SPG type for function analysis (SP Find v2)."""
+        return "spg"
+
     def __init__(
         self,
         # Target function info

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/pov_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/pov_agent.py
@@ -223,9 +223,19 @@ class POVAgent(BaseAgent):
         if self.pov_success:
             result_icon = "✅"
             result_text = "SUCCESS - Crash triggered!"
-        else:
+        elif self.stop_reason == "budget":
+            result_icon = "⏹️"
+            result_text = "COMPLETED (Budget Limit Reached)"
+        elif self.stop_reason == "timeout":
+            result_icon = "⏹️"
+            result_text = "COMPLETED (Time Limit Reached)"
+        elif self.stop_reason == "error":
             result_icon = "❌"
-            result_text = "FAILED - No crash achieved"
+            result_text = "FAILED - Error occurred"
+        else:
+            # Normal completion without crash - not a failure
+            result_icon = "⏹️"
+            result_text = "COMPLETED - No crash found"
 
         lines = []
         lines.append("")

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/pov_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/pov_agent.py
@@ -101,6 +101,11 @@ class POVAgent(BaseAgent):
     # Enable context compression for long POV sessions
     enable_context_compression: bool = True
 
+    @property
+    def agent_type(self) -> str:
+        """POV agent type."""
+        return "pov"
+
     def __init__(
         self,
         fuzzer: str = "",
@@ -125,6 +130,9 @@ class POVAgent(BaseAgent):
         fuzzer_code: str = "",
         # FuzzerManager for SP Fuzzer integration
         fuzzer_manager: Any = None,
+        # New: for numbered log files
+        index: int = 0,
+        target_name: str = "",
     ):
         """
         Initialize POV Agent.
@@ -147,6 +155,8 @@ class POVAgent(BaseAgent):
             docker_image: Docker image for running fuzzer
             fuzzer_code: Fuzzer source code (passed directly to avoid DB lookup)
             fuzzer_manager: FuzzerManager for SP Fuzzer integration
+            index: Agent index for numbered log files
+            target_name: function_name for log filename
         """
         super().__init__(
             llm_client=llm_client,
@@ -156,10 +166,11 @@ class POVAgent(BaseAgent):
             task_id=task_id,
             worker_id=worker_id,
             log_dir=log_dir,
+            index=index,
+            target_name=target_name,
+            fuzzer=fuzzer,
+            sanitizer=sanitizer,
         )
-
-        self.fuzzer = fuzzer
-        self.sanitizer = sanitizer
         self.max_pov_attempts = max_pov_attempts
         self.output_dir = Path(output_dir) if output_dir else None
         self.workspace_path = Path(workspace_path) if workspace_path else None

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/pov_report_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/pov_report_agent.py
@@ -48,6 +48,11 @@ class POVReportAgent(BaseAgent):
     4. Write a detailed, accurate report
     """
 
+    @property
+    def agent_type(self) -> str:
+        """POV type for report generation."""
+        return "pov"
+
     # Lower temperature for factual report writing
     default_temperature: float = 0.3
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/suspicious_point_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/suspicious_point_agent.py
@@ -85,6 +85,16 @@ class SuspiciousPointAgent(BaseAgent):
     # Enable context compression for verification sessions
     enable_context_compression: bool = True
 
+    @property
+    def agent_type(self) -> str:
+        """Return agent type based on mode: 'spg' for find, 'spv' for verify."""
+        return "spg" if self.mode == self.MODE_FIND else "spv"
+
+    @property
+    def is_delta(self) -> bool:
+        """Delta SPG uses single agent for all changes."""
+        return self.mode == self.MODE_FIND  # Find mode is always delta
+
     def __init__(
         self,
         mode: str = MODE_FIND,
@@ -99,6 +109,9 @@ class SuspiciousPointAgent(BaseAgent):
         task_id: str = "",
         worker_id: str = "",
         log_dir: Optional[Path] = None,
+        # New: for numbered log files
+        index: int = 0,
+        target_name: str = "",
     ):
         """
         Initialize suspicious point agent.
@@ -114,6 +127,8 @@ class SuspiciousPointAgent(BaseAgent):
             task_id: Task ID for logging
             worker_id: Worker ID for logging
             log_dir: Directory for log files
+            index: Agent index for numbered log files
+            target_name: function_name for log filename
         """
         super().__init__(
             llm_client=llm_client,
@@ -123,10 +138,12 @@ class SuspiciousPointAgent(BaseAgent):
             task_id=task_id,
             worker_id=worker_id,
             log_dir=log_dir,
+            index=index,
+            target_name=target_name,
+            fuzzer=fuzzer,
+            sanitizer=sanitizer,
         )
         self.mode = mode
-        self.fuzzer = fuzzer
-        self.sanitizer = sanitizer
         self.scan_mode = scan_mode  # "delta" or "full"
 
         # Context for find mode

--- a/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/builder.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/builder.py
@@ -718,7 +718,9 @@ class AnalyzerBuilder:
                 if self.log_dir:
                     build_dir = self.log_dir / "build"
                     build_dir.mkdir(parents=True, exist_ok=True)
-                    with open(build_dir / f"{sanitizer}.log", "a", encoding="utf-8") as f:
+                    with open(
+                        build_dir / f"{sanitizer}.log", "a", encoding="utf-8"
+                    ) as f:
                         f.write("\n" + "=" * 80 + "\n")
                         f.write(f"[BUILD ERROR] Exit code {process.returncode}\n")
                         f.write("=" * 80 + "\n")
@@ -866,7 +868,9 @@ class AnalyzerBuilder:
                 if self.log_dir:
                     build_dir = self.log_dir / "build"
                     build_dir.mkdir(parents=True, exist_ok=True)
-                    with open(build_dir / f"{sanitizer}.log", "a", encoding="utf-8") as f:
+                    with open(
+                        build_dir / f"{sanitizer}.log", "a", encoding="utf-8"
+                    ) as f:
                         f.write("\n" + "=" * 80 + "\n")
                         f.write(f"[BUILD ERROR] Exit code {process.returncode}\n")
                         f.write("=" * 80 + "\n")

--- a/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/builder.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/builder.py
@@ -697,9 +697,11 @@ class AnalyzerBuilder:
             process.wait(timeout=1800)  # 30 minutes
             elapsed = time.time() - start_time
 
-            # Write build output to log file
+            # Write build output to log file (new structure: build/{sanitizer}.log)
             if self.log_dir:
-                build_log_file = self.log_dir / f"build_{sanitizer}.log"
+                build_dir = self.log_dir / "build"
+                build_dir.mkdir(parents=True, exist_ok=True)
+                build_log_file = build_dir / f"{sanitizer}.log"
                 with open(build_log_file, "w", encoding="utf-8") as f:
                     f.write(f"# Build log for {sanitizer} sanitizer\n")
                     f.write(f"# Command: {' '.join(cmd)}\n")
@@ -712,16 +714,14 @@ class AnalyzerBuilder:
             self._fix_permissions_for_dir(fuzz_tooling_dir / "build" / "out")
 
             if process.returncode != 0:
+                # Append error to build log (no separate error.log for builds)
                 if self.log_dir:
-                    error_log = self.log_dir / "error.log"
-                    with open(error_log, "a", encoding="utf-8") as f:
-                        f.write(
-                            f"[BUILD ERROR] {sanitizer} build failed (code {process.returncode})\n"
-                        )
-                        f.write("Last 20 lines of output:\n")
-                        for line in build_output[-20:]:
-                            f.write(f"  {line}\n")
-                        f.write("\n")
+                    build_dir = self.log_dir / "build"
+                    build_dir.mkdir(parents=True, exist_ok=True)
+                    with open(build_dir / f"{sanitizer}.log", "a", encoding="utf-8") as f:
+                        f.write("\n" + "=" * 80 + "\n")
+                        f.write(f"[BUILD ERROR] Exit code {process.returncode}\n")
+                        f.write("=" * 80 + "\n")
                 return False, f"Build failed with code {process.returncode}"
 
             self.log(f"Built {sanitizer} in {elapsed:.1f}s")
@@ -845,9 +845,11 @@ class AnalyzerBuilder:
             process.wait(timeout=1800)  # 30 minutes
             elapsed = time.time() - start_time
 
-            # Write build output to separate log file
+            # Write build output to separate log file (new structure: build/{sanitizer}.log)
             if self.log_dir:
-                build_log_file = self.log_dir / f"build_{sanitizer}.log"
+                build_dir = self.log_dir / "build"
+                build_dir.mkdir(parents=True, exist_ok=True)
+                build_log_file = build_dir / f"{sanitizer}.log"
                 with open(build_log_file, "w", encoding="utf-8") as f:
                     f.write(f"# Build log for {sanitizer} sanitizer\n")
                     f.write(f"# Command: {' '.join(cmd)}\n")
@@ -860,17 +862,14 @@ class AnalyzerBuilder:
             self._fix_permissions()
 
             if process.returncode != 0:
-                # Write error to error.log
+                # Append error to build log (no separate error.log for builds)
                 if self.log_dir:
-                    error_log = self.log_dir / "error.log"
-                    with open(error_log, "a", encoding="utf-8") as f:
-                        f.write(
-                            f"[BUILD ERROR] {sanitizer} build failed (code {process.returncode})\n"
-                        )
-                        f.write("Last 20 lines of output:\n")
-                        for line in build_output[-20:]:
-                            f.write(f"  {line}\n")
-                        f.write("\n")
+                    build_dir = self.log_dir / "build"
+                    build_dir.mkdir(parents=True, exist_ok=True)
+                    with open(build_dir / f"{sanitizer}.log", "a", encoding="utf-8") as f:
+                        f.write("\n" + "=" * 80 + "\n")
+                        f.write(f"[BUILD ERROR] Exit code {process.returncode}\n")
+                        f.write("=" * 80 + "\n")
                 return False, f"Build failed with code {process.returncode}"
 
             self.log(f"Built {sanitizer} in {elapsed:.1f}s")
@@ -878,16 +877,8 @@ class AnalyzerBuilder:
 
         except subprocess.TimeoutExpired:
             process.kill()
-            if self.log_dir:
-                error_log = self.log_dir / "error.log"
-                with open(error_log, "a", encoding="utf-8") as f:
-                    f.write(f"[BUILD ERROR] {sanitizer} build timed out (30 minutes)\n")
             return False, "Build timed out (30 minutes)"
         except Exception as e:
-            if self.log_dir:
-                error_log = self.log_dir / "error.log"
-                with open(error_log, "a", encoding="utf-8") as f:
-                    f.write(f"[BUILD ERROR] {sanitizer} build exception: {e}\n")
             return False, str(e)
 
     def _move_build_output(self, sanitizer: str) -> bool:

--- a/FuzzingBrain-v2/v2/fuzzingbrain/celery_app.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/celery_app.py
@@ -46,9 +46,9 @@ class InterceptHandler(logging.Handler):
             frame = frame.f_back
             depth += 1
 
-        logger.opt(depth=depth, exception=record.exc_info).bind(
-            component="celery"
-        ).log(level, record.getMessage())
+        logger.opt(depth=depth, exception=record.exc_info).bind(component="celery").log(
+            level, record.getMessage()
+        )
 
 
 @setup_logging.connect

--- a/FuzzingBrain-v2/v2/fuzzingbrain/celery_app.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/celery_app.py
@@ -11,6 +11,7 @@ import sys
 import traceback
 
 from dotenv import load_dotenv
+from loguru import logger
 
 load_dotenv()  # Load .env file for API keys
 
@@ -29,23 +30,46 @@ app = Celery(
 )
 
 
+class InterceptHandler(logging.Handler):
+    """Intercept standard logging and redirect to Loguru."""
+
+    def emit(self, record):
+        # Get corresponding Loguru level
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Find caller from where the log originated
+        frame, depth = sys._getframe(6), 6
+        while frame and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).bind(
+            component="celery"
+        ).log(level, record.getMessage())
+
+
 @setup_logging.connect
 def configure_celery_logging(**kwargs):
     """
-    Disable Celery's default logging to console.
+    Redirect Celery logs to Loguru (celery.log via component="celery" filter).
 
-    This prevents Celery from interfering with our console output.
-    All Celery logs go to file only.
+    This prevents Celery from interfering with console output while
+    still capturing logs to our celery.log file.
     """
-    # Get Celery's logger and remove all handlers
+    # Remove default handlers and redirect to Loguru
     celery_logger = logging.getLogger("celery")
-    celery_logger.handlers = []
+    celery_logger.handlers = [InterceptHandler()]
+    celery_logger.setLevel(logging.INFO)
     celery_logger.propagate = False
 
-    # Also suppress celery.worker and celery.task loggers
+    # Also redirect celery.worker and celery.task loggers
     for name in ["celery.worker", "celery.task", "celery.app.trace"]:
         log = logging.getLogger(name)
-        log.handlers = []
+        log.handlers = [InterceptHandler()]
+        log.setLevel(logging.INFO)
         log.propagate = False
 
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/__init__.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/__init__.py
@@ -14,6 +14,7 @@ from .infrastructure import InfrastructureManager, RedisManager, CeleryWorkerMan
 from .logging import (
     logger,
     setup_logging,
+    setup_celery_logging,
     setup_console_only,
     get_log_dir,
     add_task_log,
@@ -51,6 +52,7 @@ __all__ = [
     # Logging
     "logger",
     "setup_logging",
+    "setup_celery_logging",
     "setup_console_only",
     "get_log_dir",
     "add_task_log",

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/dispatcher.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/dispatcher.py
@@ -541,11 +541,9 @@ def generate(variant: int = 1) -> bytes:
         }
 
         # Dispatch Celery task with dynamic time limit based on config
-        # Convert minutes to seconds, add 5 min buffer for soft limit
+        # Soft timeout at 90% of hard timeout - gives 10% buffer for graceful shutdown
         timeout_seconds = self.config.timeout_minutes * 60
-        soft_timeout_seconds = max(
-            timeout_seconds - 300, timeout_seconds // 2
-        )  # 5 min before hard limit
+        soft_timeout_seconds = int(timeout_seconds * 0.9)
 
         result = run_worker.apply_async(
             args=[assignment],

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/dispatcher.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/dispatcher.py
@@ -937,11 +937,18 @@ def generate(variant: int = 1) -> bytes:
             )
             actual_pov_count += fuzzer_discovered_count
 
+            # Determine effective status:
+            # - If worker failed but has results (SPs or POVs), mark as "interrupted"
+            # - This handles timeout cases where work was done but Celery task was killed
+            effective_status = worker.status.value
+            if effective_status == "failed" and (sp_count > 0 or actual_pov_count > 0):
+                effective_status = "interrupted"
+
             result = {
                 "worker_id": worker.worker_id,
                 "fuzzer": worker.fuzzer,
                 "sanitizer": worker.sanitizer,
-                "status": worker.status.value,
+                "status": effective_status,
                 "sps_found": sp_count,
                 "sps_merged": merged_count,
                 "povs_found": actual_pov_count,  # Use DB count instead of worker's self-report

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
@@ -63,6 +63,136 @@ logger.remove()
 # Global log directory for current task
 _current_log_dir: Optional[Path] = None
 
+# =============================================================================
+# Log Path Helpers
+# =============================================================================
+
+# Max length for names in filenames (direction_name, function_name)
+MAX_NAME_LENGTH = 20
+
+
+def truncate_name(name: str, max_len: int = MAX_NAME_LENGTH) -> str:
+    """
+    Truncate a name for use in filenames.
+
+    Args:
+        name: The name to truncate
+        max_len: Maximum length (default: 20)
+
+    Returns:
+        Truncated name
+    """
+    if len(name) <= max_len:
+        return name
+    return name[:max_len]
+
+
+def create_log_directories(log_dir: Path, workers: list = None) -> None:
+    """
+    Create the log directory structure.
+
+    Args:
+        log_dir: Base log directory for this task
+        workers: Optional list of (fuzzer, sanitizer) tuples to create worker dirs
+    """
+    # Create top-level directories
+    (log_dir / "build").mkdir(parents=True, exist_ok=True)
+    (log_dir / "analyzer").mkdir(parents=True, exist_ok=True)
+    (log_dir / "fuzzer").mkdir(parents=True, exist_ok=True)
+    (log_dir / "worker").mkdir(parents=True, exist_ok=True)
+
+    # Create worker subdirectories if specified
+    if workers:
+        for fuzzer, sanitizer in workers:
+            worker_dir = log_dir / "worker" / f"{fuzzer}_{sanitizer}"
+            worker_dir.mkdir(parents=True, exist_ok=True)
+            # Create agent subdirectories
+            (worker_dir / "agent" / "direction").mkdir(parents=True, exist_ok=True)
+            (worker_dir / "agent" / "seed").mkdir(parents=True, exist_ok=True)
+            (worker_dir / "agent" / "sp" / "generate").mkdir(parents=True, exist_ok=True)
+            (worker_dir / "agent" / "sp" / "verify").mkdir(parents=True, exist_ok=True)
+            (worker_dir / "agent" / "pov").mkdir(parents=True, exist_ok=True)
+
+
+def get_worker_log_dir(fuzzer: str, sanitizer: str) -> Optional[Path]:
+    """
+    Get the log directory for a specific worker.
+
+    Args:
+        fuzzer: Fuzzer name
+        sanitizer: Sanitizer name
+
+    Returns:
+        Path to worker log directory, or None if logging not initialized
+    """
+    if _current_log_dir is None:
+        return None
+    worker_dir = _current_log_dir / "worker" / f"{fuzzer}_{sanitizer}"
+    worker_dir.mkdir(parents=True, exist_ok=True)
+    return worker_dir
+
+
+def get_agent_log_path(
+    agent_type: str,
+    fuzzer: str,
+    sanitizer: str,
+    index: int = 0,
+    target_name: str = "",
+    is_delta: bool = False,
+) -> Optional[Path]:
+    """
+    Get the log file path for an agent.
+
+    Args:
+        agent_type: One of "direction", "seed", "spg", "spv", "pov"
+        fuzzer: Fuzzer name
+        sanitizer: Sanitizer name
+        index: Agent index (1-based for display, used in filename)
+        target_name: direction_name or function_name
+        is_delta: Whether this is delta scan mode (for SPG)
+
+    Returns:
+        Path to agent log file (without extension), or None if logging not initialized
+    """
+    if _current_log_dir is None:
+        return None
+
+    worker_dir = _current_log_dir / "worker" / f"{fuzzer}_{sanitizer}"
+
+    # Truncate target name for filename
+    name_suffix = f"_{truncate_name(target_name)}" if target_name else ""
+
+    if agent_type == "direction":
+        agent_dir = worker_dir / "agent" / "direction"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return agent_dir / "D_agent"
+
+    elif agent_type == "seed":
+        agent_dir = worker_dir / "agent" / "seed"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return agent_dir / f"Seed_{index}{name_suffix}"
+
+    elif agent_type == "spg":
+        agent_dir = worker_dir / "agent" / "sp" / "generate"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        if is_delta:
+            return agent_dir / "SPG_delta"
+        else:
+            return agent_dir / f"SPG_{index}{name_suffix}"
+
+    elif agent_type == "spv":
+        agent_dir = worker_dir / "agent" / "sp" / "verify"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return agent_dir / f"SPV_{index}{name_suffix}"
+
+    elif agent_type == "pov":
+        agent_dir = worker_dir / "agent" / "pov"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return agent_dir / f"POV_{index}{name_suffix}"
+
+    else:
+        raise ValueError(f"Unknown agent type: {agent_type}")
+
 
 # =============================================================================
 # Worker Colors
@@ -412,8 +542,11 @@ def setup_logging(
 
     _current_log_dir = log_dir
 
-    # Write logo and metadata header to log file
-    log_file = log_dir / "fuzzingbrain.log"
+    # Create directory structure
+    create_log_directories(log_dir)
+
+    # Write logo and metadata header to controller log
+    log_file = log_dir / "controller.log"
     with open(log_file, "w", encoding="utf-8") as f:
         f.write(LOGO)
         f.write("\n")
@@ -442,7 +575,7 @@ def setup_logging(
         colorize=True,
     )
 
-    # Main log file - append to existing (with header)
+    # Main log file (controller.log) - append to existing (with header)
     logger.add(
         log_file,
         level=file_level,
@@ -453,18 +586,231 @@ def setup_logging(
         mode="a",  # Append mode
     )
 
-    # Error log file - only errors and above
-    logger.add(
-        log_dir / "error.log",
-        level="ERROR",
-        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}",
-        rotation="10 MB",
-        encoding="utf-8",
-    )
+    # Note: error.log is now per-worker, created by setup_worker_logging()
 
     logger.info(f"Logging initialized: {log_dir}")
 
     return log_dir
+
+
+def setup_worker_logging(
+    fuzzer: str,
+    sanitizer: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Path]:
+    """
+    Setup logging for a worker process.
+
+    Creates worker.log and error.log in the worker directory.
+
+    Args:
+        fuzzer: Fuzzer name
+        sanitizer: Sanitizer name
+        metadata: Worker metadata for header
+
+    Returns:
+        Path to worker log directory, or None if main logging not initialized
+    """
+    if _current_log_dir is None:
+        return None
+
+    worker_dir = get_worker_log_dir(fuzzer, sanitizer)
+    if worker_dir is None:
+        return None
+
+    # Create agent subdirectories
+    (worker_dir / "agent" / "direction").mkdir(parents=True, exist_ok=True)
+    (worker_dir / "agent" / "seed").mkdir(parents=True, exist_ok=True)
+    (worker_dir / "agent" / "sp" / "generate").mkdir(parents=True, exist_ok=True)
+    (worker_dir / "agent" / "sp" / "verify").mkdir(parents=True, exist_ok=True)
+    (worker_dir / "agent" / "pov").mkdir(parents=True, exist_ok=True)
+
+    # Write worker log header
+    worker_log = worker_dir / "worker.log"
+    with open(worker_log, "w", encoding="utf-8") as f:
+        f.write(get_logo("worker"))
+        f.write("\n")
+        if metadata:
+            f.write(_create_worker_header(metadata))
+            f.write("\n")
+
+    # Add worker-specific log handler (with [Worker] prefix per design doc)
+    logger.add(
+        worker_log,
+        level="INFO",
+        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | [Worker] {message}",
+        filter=lambda record: record["extra"].get("worker") == f"{fuzzer}_{sanitizer}",
+        rotation="50 MB",
+        encoding="utf-8",
+        mode="a",
+    )
+
+    # Add worker error log (with [Worker] prefix per design doc)
+    logger.add(
+        worker_dir / "error.log",
+        level="WARNING",
+        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | [Worker] {message}",
+        filter=lambda record: record["extra"].get("worker") == f"{fuzzer}_{sanitizer}",
+        rotation="50 MB",
+        encoding="utf-8",
+    )
+
+    return worker_dir
+
+
+def get_worker_logger(fuzzer: str, sanitizer: str):
+    """
+    Get a logger bound to a specific worker.
+
+    Args:
+        fuzzer: Fuzzer name
+        sanitizer: Sanitizer name
+
+    Returns:
+        Bound logger instance
+    """
+    return logger.bind(worker=f"{fuzzer}_{sanitizer}")
+
+
+def setup_analyzer_logging(metadata: Optional[Dict[str, Any]] = None) -> Optional[Path]:
+    """
+    Setup logging for the analyzer server.
+
+    Creates analyzer/server.log in the log directory.
+
+    Args:
+        metadata: Analyzer metadata for header
+
+    Returns:
+        Path to analyzer log file, or None if main logging not initialized
+    """
+    if _current_log_dir is None:
+        return None
+
+    analyzer_dir = _current_log_dir / "analyzer"
+    analyzer_dir.mkdir(parents=True, exist_ok=True)
+
+    analyzer_log = analyzer_dir / "server.log"
+
+    # Write analyzer log header
+    with open(analyzer_log, "w", encoding="utf-8") as f:
+        f.write(get_logo("analyzer"))
+        f.write("\n")
+        if metadata:
+            f.write(_create_analyzer_header(metadata))
+            f.write("\n")
+
+    # Add analyzer-specific log handler
+    logger.add(
+        analyzer_log,
+        level="INFO",
+        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | [Analyzer] {message}",
+        filter=lambda record: record["extra"].get("component") == "analyzer",
+        rotation="50 MB",
+        encoding="utf-8",
+        mode="a",
+    )
+
+    return analyzer_log
+
+
+def get_analyzer_logger():
+    """
+    Get a logger bound to the analyzer component.
+
+    Returns:
+        Bound logger instance
+    """
+    return logger.bind(component="analyzer")
+
+
+def setup_celery_logging() -> Optional[Path]:
+    """
+    Setup logging for Celery workers.
+
+    Creates celery.log in the root log directory.
+
+    Returns:
+        Path to celery log file, or None if main logging not initialized
+    """
+    if _current_log_dir is None:
+        return None
+
+    celery_log = _current_log_dir / "celery.log"
+
+    # Add celery-specific log handler
+    logger.add(
+        celery_log,
+        level="INFO",
+        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | [Celery] {message}",
+        filter=lambda record: record["extra"].get("component") == "celery",
+        rotation="50 MB",
+        encoding="utf-8",
+    )
+
+    return celery_log
+
+
+def get_celery_logger():
+    """
+    Get a logger bound to the Celery component.
+
+    Returns:
+        Bound logger instance
+    """
+    return logger.bind(component="celery")
+
+
+def setup_fuzzer_instance_logging(
+    fuzzer: str,
+    sanitizer: str,
+) -> Optional[Path]:
+    """
+    Setup logging for a fuzzer instance.
+
+    Creates fuzzer/{fuzzer}_{sanitizer}/instance.log in the log directory.
+
+    Args:
+        fuzzer: Fuzzer name
+        sanitizer: Sanitizer name
+
+    Returns:
+        Path to fuzzer instance log file, or None if main logging not initialized
+    """
+    if _current_log_dir is None:
+        return None
+
+    fuzzer_dir = _current_log_dir / "fuzzer" / f"{fuzzer}_{sanitizer}"
+    fuzzer_dir.mkdir(parents=True, exist_ok=True)
+
+    instance_log = fuzzer_dir / "instance.log"
+
+    # Add fuzzer instance-specific log handler
+    instance_key = f"{fuzzer}_{sanitizer}"
+    logger.add(
+        instance_log,
+        level="DEBUG",
+        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | [Fuzzer] {message}",
+        filter=lambda record: record["extra"].get("fuzzer_instance") == instance_key,
+        rotation="50 MB",
+        encoding="utf-8",
+    )
+
+    return instance_log
+
+
+def get_fuzzer_instance_logger(fuzzer: str, sanitizer: str):
+    """
+    Get a logger bound to a specific fuzzer instance.
+
+    Args:
+        fuzzer: Fuzzer name
+        sanitizer: Sanitizer name
+
+    Returns:
+        Bound logger instance
+    """
+    return logger.bind(fuzzer_instance=f"{fuzzer}_{sanitizer}")
 
 
 def setup_console_only(level: str = "INFO"):
@@ -870,15 +1216,28 @@ def create_final_summary(
 __all__ = [
     "logger",
     "setup_logging",
+    "setup_worker_logging",
+    "setup_analyzer_logging",
+    "setup_celery_logging",
+    "setup_fuzzer_instance_logging",
     "setup_console_only",
     "get_log_dir",
+    "get_worker_log_dir",
+    "get_agent_log_path",
     "get_logo",
     "get_worker_banner_and_header",
     "get_analyzer_banner_and_header",
     "get_agent_banner_and_header",
     "add_task_log",
     "get_task_logger",
+    "get_worker_logger",
+    "get_analyzer_logger",
+    "get_celery_logger",
+    "get_fuzzer_instance_logger",
     "create_worker_summary",
     "create_final_summary",
+    "create_log_directories",
+    "truncate_name",
     "WorkerColors",
+    "MAX_NAME_LENGTH",
 ]

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
@@ -109,7 +109,9 @@ def create_log_directories(log_dir: Path, workers: list = None) -> None:
             # Create agent subdirectories
             (worker_dir / "agent" / "direction").mkdir(parents=True, exist_ok=True)
             (worker_dir / "agent" / "seed").mkdir(parents=True, exist_ok=True)
-            (worker_dir / "agent" / "sp" / "generate").mkdir(parents=True, exist_ok=True)
+            (worker_dir / "agent" / "sp" / "generate").mkdir(
+                parents=True, exist_ok=True
+            )
             (worker_dir / "agent" / "sp" / "verify").mkdir(parents=True, exist_ok=True)
             (worker_dir / "agent" / "pov").mkdir(parents=True, exist_ok=True)
 
@@ -1041,9 +1043,7 @@ def create_final_summary(
     if failed > 0:
         workers_parts.append(f"{failed} failed")
     workers_str = ", ".join(workers_parts)
-    lines.append(
-        "│" + f"  Workers:       {workers_str}".ljust(table_width) + "│"
-    )
+    lines.append("│" + f"  Workers:       {workers_str}".ljust(table_width) + "│")
     lines.append("│" + f"  SPs Found:     {total_sps}".ljust(table_width) + "│")
     if dedup_count > 0:
         lines.append(

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
@@ -986,6 +986,7 @@ def create_final_summary(
     # Count statistics
     total = len(workers)
     completed = sum(1 for w in workers if w.get("status") == "completed")
+    interrupted = sum(1 for w in workers if w.get("status") == "interrupted")
     failed = sum(1 for w in workers if w.get("status") == "failed")
     total_sps = sum(w.get("sps_found", 0) for w in workers)
     total_povs = sum(w.get("povs_found", 0) for w in workers)
@@ -1033,12 +1034,15 @@ def create_final_summary(
         + f"  Total Time:    {total_elapsed_minutes:.1f} minutes".ljust(table_width)
         + "│"
     )
+    # Build workers summary string
+    workers_parts = [f"{completed}/{total} completed"]
+    if interrupted > 0:
+        workers_parts.append(f"{interrupted} interrupted")
+    if failed > 0:
+        workers_parts.append(f"{failed} failed")
+    workers_str = ", ".join(workers_parts)
     lines.append(
-        "│"
-        + f"  Workers:       {completed}/{total} completed, {failed} failed".ljust(
-            table_width
-        )
-        + "│"
+        "│" + f"  Workers:       {workers_str}".ljust(table_width) + "│"
     )
     lines.append("│" + f"  SPs Found:     {total_sps}".ljust(table_width) + "│")
     if dedup_count > 0:
@@ -1132,7 +1136,12 @@ def create_final_summary(
             fuzzer = fuzzer[: col_fuzzer - 4] + ".."
 
         status = w.get("status", "unknown")
-        status_display = "✓ " + status if status == "completed" else "✗ " + status
+        if status == "completed":
+            status_display = "✓ " + status
+        elif status == "interrupted":
+            status_display = "⚡ " + status  # Lightning bolt for interrupted
+        else:
+            status_display = "✗ " + status
 
         # Get duration string
         duration_str = w.get("duration_str", "N/A")

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
@@ -503,6 +503,24 @@ def get_log_dir() -> Optional[Path]:
     return _current_log_dir
 
 
+def set_log_dir(log_dir: Union[str, Path]) -> Path:
+    """
+    Set current task's log directory.
+
+    Used by worker processes to set the log directory from assignment.
+    The directory must already exist (created by main process).
+
+    Args:
+        log_dir: Path to the log directory
+
+    Returns:
+        Path to the log directory
+    """
+    global _current_log_dir
+    _current_log_dir = Path(log_dir)
+    return _current_log_dir
+
+
 def setup_logging(
     project_name: str,
     task_id: str,
@@ -1222,6 +1240,7 @@ __all__ = [
     "setup_fuzzer_instance_logging",
     "setup_console_only",
     "get_log_dir",
+    "set_log_dir",
     "get_worker_log_dir",
     "get_agent_log_path",
     "get_logo",

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
@@ -152,7 +152,8 @@ def get_agent_log_path(
         is_delta: Whether this is delta scan mode (for SPG)
 
     Returns:
-        Path to agent log file (without extension), or None if logging not initialized
+        Path to agent log file (without extension), or None if logging not initialized.
+        If file already exists, appends timestamp to ensure uniqueness.
     """
     if _current_log_dir is None:
         return None
@@ -165,33 +166,43 @@ def get_agent_log_path(
     if agent_type == "direction":
         agent_dir = worker_dir / "agent" / "direction"
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return agent_dir / "D_agent"
+        base_path = agent_dir / "D_agent"
 
     elif agent_type == "seed":
         agent_dir = worker_dir / "agent" / "seed"
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return agent_dir / f"Seed_{index}{name_suffix}"
+        base_path = agent_dir / f"Seed_{index}{name_suffix}"
 
     elif agent_type == "spg":
         agent_dir = worker_dir / "agent" / "sp" / "generate"
         agent_dir.mkdir(parents=True, exist_ok=True)
         if is_delta:
-            return agent_dir / "SPG_delta"
+            base_path = agent_dir / "SPG_delta"
         else:
-            return agent_dir / f"SPG_{index}{name_suffix}"
+            base_path = agent_dir / f"SPG_{index}{name_suffix}"
 
     elif agent_type == "spv":
         agent_dir = worker_dir / "agent" / "sp" / "verify"
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return agent_dir / f"SPV_{index}{name_suffix}"
+        base_path = agent_dir / f"SPV_{index}{name_suffix}"
 
     elif agent_type == "pov":
         agent_dir = worker_dir / "agent" / "pov"
         agent_dir.mkdir(parents=True, exist_ok=True)
-        return agent_dir / f"POV_{index}{name_suffix}"
+        base_path = agent_dir / f"POV_{index}{name_suffix}"
 
     else:
         raise ValueError(f"Unknown agent type: {agent_type}")
+
+    # Check for filename conflict and add timestamp if needed
+    log_file = Path(str(base_path) + ".log")
+    if log_file.exists():
+        import datetime
+
+        timestamp = datetime.datetime.now().strftime("%H%M%S")
+        return Path(str(base_path) + f"_{timestamp}")
+
+    return base_path
 
 
 # =============================================================================

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/logging.py
@@ -9,7 +9,7 @@ import sys
 import traceback
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Union
 
 from loguru import logger
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/task_processor.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/task_processor.py
@@ -1074,13 +1074,12 @@ class TaskProcessor:
                             import requests
 
                             resp = requests.get(
-                                f"{eval_server}/api/tasks/{task.task_id}", timeout=5
+                                f"{eval_server}/api/v1/costs/task/{task.task_id}",
+                                timeout=5,
                             )
                             if resp.status_code == 200:
                                 data = resp.json()
-                                total_cost = data.get("costs", {}).get(
-                                    "total_cost", 0.0
-                                )
+                                total_cost = data.get("total_cost", 0.0)
                     except Exception as e:
                         logger.debug(f"Failed to get cost from eval_server: {e}")
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/monitor.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/monitor.py
@@ -172,10 +172,15 @@ class FuzzerMonitor:
         self._log_sink_id: Optional[int] = None
         self._log_path: Optional[Path] = None
         # Use log_dir if provided, otherwise fall back to workspace_path
+        # New structure: fuzzer/monitor.log
         if log_dir:
-            self._log_path = Path(log_dir) / "fuzzer_monitor.log"
+            fuzzer_log_dir = Path(log_dir) / "fuzzer"
+            fuzzer_log_dir.mkdir(parents=True, exist_ok=True)
+            self._log_path = fuzzer_log_dir / "monitor.log"
         elif self.workspace_path:
-            self._log_path = self.workspace_path / "fuzzer_monitor.log"
+            fuzzer_log_dir = self.workspace_path / "fuzzer"
+            fuzzer_log_dir.mkdir(parents=True, exist_ok=True)
+            self._log_path = fuzzer_log_dir / "monitor.log"
 
         logger.debug(
             f"[FuzzerMonitor:{task_id}] Initialized (thread-based, "

--- a/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/seed_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/seed_agent.py
@@ -189,6 +189,11 @@ class SeedAgent(BaseAgent):
         False  # Short conversations, no compression needed
     )
 
+    @property
+    def agent_type(self) -> str:
+        """Seed agent type."""
+        return "seed"
+
     def __init__(
         self,
         task_id: str,
@@ -203,6 +208,9 @@ class SeedAgent(BaseAgent):
         model: Optional[Union[ModelInfo, str]] = None,
         max_iterations: int = 5,  # Short iterations for seed generation
         log_dir: Optional[Path] = None,
+        # New: for numbered log files
+        index: int = 0,
+        target_name: str = "",
     ):
         """
         Initialize SeedAgent.
@@ -220,6 +228,8 @@ class SeedAgent(BaseAgent):
             model: Model to use
             max_iterations: Max iterations (default 5)
             log_dir: Log directory
+            index: Agent index for numbered log files
+            target_name: direction_name for log filename
         """
         super().__init__(
             llm_client=llm_client,
@@ -229,10 +239,11 @@ class SeedAgent(BaseAgent):
             task_id=task_id,
             worker_id=worker_id,
             log_dir=log_dir,
+            index=index,
+            target_name=target_name,
+            fuzzer=fuzzer,
+            sanitizer=sanitizer,
         )
-
-        self.fuzzer = fuzzer
-        self.sanitizer = sanitizer
         self.fuzzer_manager = fuzzer_manager
         self.repos = repos
         self.fuzzer_source = fuzzer_source

--- a/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/seed_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/seed_agent.py
@@ -8,9 +8,11 @@ Uses BaseAgent to generate targeted seeds based on:
 - FP (False Positive) analysis (generate seeds to find similar bugs)
 """
 
+import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from fastmcp import Client
 from loguru import logger
 
 from ..agents.base import BaseAgent
@@ -456,6 +458,35 @@ Generate seeds NOW or this run will produce nothing useful."""
         """Clean up seed tool context after running."""
         clear_seed_context(self.worker_id)
 
+    async def _execute_tool(
+        self,
+        client: Client,
+        tool_name: str,
+        tool_args: Dict[str, Any],
+    ) -> str:
+        """
+        Execute tool and track seeds_generated from create_seed results.
+
+        The MCP server runs in an isolated context, so we need to parse
+        the tool result to get the actual seeds_generated count.
+        """
+        result = await super()._execute_tool(client, tool_name, tool_args)
+
+        # Track seeds from create_seed tool results
+        if tool_name == "create_seed":
+            try:
+                result_data = json.loads(result)
+                if result_data.get("success") and "seeds_generated" in result_data:
+                    self.seeds_generated += result_data["seeds_generated"]
+                    logger.debug(
+                        f"[SeedAgent] Tracked {result_data['seeds_generated']} seeds, "
+                        f"total: {self.seeds_generated}"
+                    )
+            except (json.JSONDecodeError, TypeError):
+                pass  # Non-JSON result, ignore
+
+        return result
+
     async def run_async(self, **kwargs) -> str:
         """Run the seed agent."""
         # Setup context before running
@@ -464,13 +495,8 @@ Generate seeds NOW or this run will produce nothing useful."""
         try:
             result = await super().run_async(**kwargs)
         finally:
-            # Read seeds_generated from context BEFORE cleanup
-            from .seed_tools import get_seed_context
-
-            ctx = get_seed_context(self.worker_id)
-            self.seeds_generated = ctx.get("seeds_generated", 0)
-
             # Always cleanup context
+            # Note: seeds_generated is tracked in _execute_tool via tool results
             self._cleanup_context()
 
         return result

--- a/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/seed_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/seed_agent.py
@@ -257,6 +257,10 @@ class SeedAgent(BaseAgent):
         self.delta_id: Optional[str] = None
         self.seed_type: str = "direction"  # "direction", "fp", or "delta"
 
+        # Unique context ID for parallel execution
+        # Prevents context collision when multiple SeedAgents run concurrently
+        self._context_id: str = f"{worker_id}_{id(self)}"
+
         # Stats
         self.seeds_generated = 0
 
@@ -269,6 +273,15 @@ class SeedAgent(BaseAgent):
     def include_seed_tools(self) -> bool:
         """Include seed tools in MCP server."""
         return True
+
+    @property
+    def mcp_context_id(self) -> str:
+        """Unique context ID for MCP tool lookup.
+
+        SeedAgents may run in parallel, so each needs a unique context_id
+        to prevent collision in _seed_contexts dict.
+        """
+        return self._context_id
 
     def _get_agent_metadata(self) -> dict:
         """Get metadata for agent banner."""
@@ -431,9 +444,10 @@ Generate seeds NOW or this run will produce nothing useful."""
     def _setup_context(self) -> None:
         """Set up seed tool context before running."""
         # Set seed context for create_seed tool
+        # Use _context_id (unique per instance) to prevent collision in parallel execution
         set_seed_context(
             task_id=self.task_id,
-            worker_id=self.worker_id,
+            worker_id=self._context_id,  # Unique context ID, not shared worker_id
             direction_id=self.direction_id,
             sp_id=self.sp_id,
             delta_id=self.delta_id,
@@ -456,7 +470,7 @@ Generate seeds NOW or this run will produce nothing useful."""
 
     def _cleanup_context(self) -> None:
         """Clean up seed tool context after running."""
-        clear_seed_context(self.worker_id)
+        clear_seed_context(self._context_id)
 
     async def _execute_tool(
         self,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/main.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/main.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from .core import Config, Task, JobType, ScanMode, setup_logging, setup_console_only
+from .core import Config, Task, JobType, ScanMode, setup_logging, setup_celery_logging, setup_console_only
 from .db import MongoDB, RepositoryManager, init_repos
 
 
@@ -585,6 +585,8 @@ def process_task(task: Task, config: Config) -> dict:
             "Delta Commit": config.delta_commit,
         },
     )
+    # Setup celery.log for Celery process logs
+    setup_celery_logging()
     print_info(f"Logs: {log_dir}")
 
     print_info(f"Task ID: {task.task_id}")

--- a/FuzzingBrain-v2/v2/fuzzingbrain/main.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/main.py
@@ -19,7 +19,15 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from .core import Config, Task, JobType, ScanMode, setup_logging, setup_celery_logging, setup_console_only
+from .core import (
+    Config,
+    Task,
+    JobType,
+    ScanMode,
+    setup_logging,
+    setup_celery_logging,
+    setup_console_only,
+)
 from .db import MongoDB, RepositoryManager, init_repos
 
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/pipeline.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/pipeline.py
@@ -292,6 +292,8 @@ class AgentPipeline:
                 )
 
                 # Run verification agent
+                # Extract index from agent_id (e.g., "verify_1" -> 1)
+                agent_index = int(agent_id.split("_")[1]) if "_" in agent_id else 0
                 verify_agent = SuspiciousPointAgent(
                     mode="verify",
                     fuzzer=self.fuzzer,
@@ -301,6 +303,8 @@ class AgentPipeline:
                     task_id=self.task_id,
                     worker_id=agent_id,
                     log_dir=self.log_dir,
+                    index=agent_index,
+                    target_name=sp.function_name or "",
                 )
                 verify_agent.set_verify_context(sp.to_dict())
 
@@ -500,6 +504,8 @@ class AgentPipeline:
                         )
 
                 # Run POV agent with fuzzer code
+                # Extract index from agent_id (e.g., "pov_1" -> 1)
+                agent_index = int(agent_id.split("_")[1]) if "_" in agent_id else 0
                 pov_agent = POVAgent(
                     fuzzer=self.fuzzer,
                     sanitizer=self.sanitizer,
@@ -516,6 +522,8 @@ class AgentPipeline:
                     workspace_path=self.workspace_path,
                     fuzzer_code=self.fuzzer_code,
                     fuzzer_manager=self.fuzzer_manager,  # For SP Fuzzer integration
+                    index=agent_index,
+                    target_name=sp.function_name or "",
                 )
 
                 result = await pov_agent.generate_pov_async(sp.to_dict())

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_base.py
@@ -411,7 +411,7 @@ class POVBaseStrategy(BaseStrategy):
                 # Create SeedAgent for this FP
                 seed_agent = SeedAgent(
                     task_id=self.task_id,
-                    worker_id=self.worker_id,
+                    worker_id=f"{self.worker_id}_fp_seed_{seed_index}",  # Unique per agent
                     fuzzer=self.fuzzer,
                     sanitizer=self.sanitizer,
                     fuzzer_manager=fuzzer_manager,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_base.py
@@ -55,7 +55,7 @@ class POVBaseStrategy(BaseStrategy):
         if self.executor.analysis_socket_path:
             set_analyzer_context(
                 socket_path=self.executor.analysis_socket_path,
-                client_id=f"agent_{self.fuzzer}_{self.sanitizer}",
+                client_id=f"{self.fuzzer}_{self.sanitizer}",
             )
 
         # Set SP context (harness_name, sanitizer) for SP isolation
@@ -80,6 +80,17 @@ class POVBaseStrategy(BaseStrategy):
             "full" for full-scan (full reachability analysis in verify)
         """
         return "full"  # Default to full-scan
+
+    @property
+    def agent_log_dir(self):
+        """Get correct agent log directory path.
+
+        Returns:
+            Path to worker/{fuzzer}_{sanitizer}/agent/ directory
+        """
+        if self.log_dir:
+            return self.log_dir / "worker" / f"{self.fuzzer}_{self.sanitizer}" / "agent"
+        return self.results_path
 
     @abstractmethod
     def _find_suspicious_points(self) -> List[SuspiciousPoint]:
@@ -294,7 +305,7 @@ class POVBaseStrategy(BaseStrategy):
         from ...agents import SuspiciousPointAgent
 
         # Create verification agent (reused for all points sequentially)
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
         agent = SuspiciousPointAgent(
             fuzzer=self.fuzzer,
             sanitizer=self.sanitizer,
@@ -393,7 +404,7 @@ class POVBaseStrategy(BaseStrategy):
             self.log_warning("SeedAgent not available, skipping FP seed generation")
             return
 
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
 
         for seed_index, point in enumerate(fp_points, start=1):
             try:
@@ -636,7 +647,7 @@ class POVBaseStrategy(BaseStrategy):
             scan_mode=self.scan_mode,  # Pass scan_mode to pipeline
             config=config,
             output_dir=self.povs_path,
-            log_dir=self.log_dir / "agent" if self.log_dir else None,
+            log_dir=self.agent_log_dir,
             workspace_path=self.workspace_path,
             worker_id=self.worker_id,  # For SP Fuzzer lifecycle
             fuzzer_code=fuzzer_code,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_base.py
@@ -293,7 +293,7 @@ class POVBaseStrategy(BaseStrategy):
         # Lazy import to avoid circular dependency
         from ...agents import SuspiciousPointAgent
 
-        # Create verification agent
+        # Create verification agent (reused for all points sequentially)
         agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
         agent = SuspiciousPointAgent(
             fuzzer=self.fuzzer,
@@ -304,6 +304,7 @@ class POVBaseStrategy(BaseStrategy):
             task_id=self.task_id,
             worker_id=self.worker_id,
             log_dir=agent_log_dir,
+            index=1,  # Single agent for sequential verification
         )
 
         verified = []
@@ -394,7 +395,7 @@ class POVBaseStrategy(BaseStrategy):
 
         agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
 
-        for point in fp_points:
+        for seed_index, point in enumerate(fp_points, start=1):
             try:
                 # Create SeedAgent for this FP
                 seed_agent = SeedAgent(
@@ -406,6 +407,8 @@ class POVBaseStrategy(BaseStrategy):
                     repos=self.repos,
                     log_dir=agent_log_dir,
                     max_iterations=3,  # Quick seed generation
+                    index=seed_index,
+                    target_name=point.function_name or "",
                 )
 
                 # Run seed generation (sync wrapper for async)

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_delta.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_delta.py
@@ -411,6 +411,8 @@ class POVDeltaStrategy(POVBaseStrategy):
             workspace_path=self.workspace_path,
             log_dir=agent_log_dir,
             max_iterations=15,  # Allow more iterations for delta seeds (with urgency forcing on last 2)
+            index=1,  # Single seed agent for delta
+            target_name="delta",
         )
 
         # Generate seeds (run async in sync context)

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_delta.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_delta.py
@@ -56,7 +56,7 @@ class POVDeltaStrategy(POVBaseStrategy):
 
         # Create the suspicious point agent for delta analysis
         # Note: Use higher max_iterations for finding SPs (not just verifying)
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
         self._agent = SuspiciousPointAgent(
             fuzzer=self.fuzzer,
             sanitizer=self.sanitizer,
@@ -397,9 +397,7 @@ class POVDeltaStrategy(POVBaseStrategy):
         # Create SeedAgent
         from ...fuzzer import SeedAgent
 
-        agent_log_dir = (
-            self.log_dir / "seed_agent" if self.log_dir else self.results_path
-        )
+        agent_log_dir = self.agent_log_dir
         seed_agent = SeedAgent(
             task_id=self.task_id,
             worker_id=self.worker_id,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_delta.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_delta.py
@@ -400,7 +400,7 @@ class POVDeltaStrategy(POVBaseStrategy):
         agent_log_dir = self.agent_log_dir
         seed_agent = SeedAgent(
             task_id=self.task_id,
-            worker_id=self.worker_id,
+            worker_id=f"{self.worker_id}_delta_seed",  # Unique for delta seed agent
             fuzzer=self.fuzzer,
             sanitizer=self.sanitizer,
             fuzzer_manager=fuzzer_manager,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
@@ -1101,7 +1101,7 @@ class POVFullscanStrategy(POVBaseStrategy):
             try:
                 seed_agent = SeedAgent(
                     task_id=self.task_id,
-                    worker_id=self.worker_id,
+                    worker_id=f"{self.worker_id}_seed_{seed_index}",  # Unique per agent
                     fuzzer=self.fuzzer,
                     sanitizer=self.sanitizer,
                     model=CLAUDE_OPUS_4_5,  # Force Opus for seed generation

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
@@ -559,6 +559,7 @@ class POVFullscanStrategy(POVBaseStrategy):
             worker_id=f"{self.worker_id}_agent_{index}",
             log_dir=agent_log_dir,
             max_iterations=100,
+            index=index + 1,  # 1-based index for log files
         )
 
         try:
@@ -1096,7 +1097,7 @@ class POVFullscanStrategy(POVBaseStrategy):
             key=lambda d: {"high": 0, "medium": 1, "low": 2}.get(d.risk_level, 3),
         )
 
-        for direction in sorted_directions[:5]:  # Top 5 directions
+        for seed_index, direction in enumerate(sorted_directions[:5], start=1):  # Top 5 directions
             try:
                 # Create SeedAgent for this direction
                 seed_agent = SeedAgent(
@@ -1110,6 +1111,8 @@ class POVFullscanStrategy(POVBaseStrategy):
                     fuzzer_source=fuzzer_code,
                     log_dir=agent_log_dir,
                     max_iterations=20,  # Same as DirectionPlanningAgent
+                    index=seed_index,
+                    target_name=direction.name,
                 )
 
                 # Generate Direction Seeds

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
@@ -957,6 +957,7 @@ class POVFullscanStrategy(POVBaseStrategy):
                 task_id=self.task_id,
                 worker_id=f"Func_{index}_{self.fuzzer}_{self.sanitizer}",
                 log_dir=agent_log_dir,
+                index=index,  # For log file naming: SPG_{index}_{function_name}.log
             )
         else:
             agent = FunctionAnalysisAgent(
@@ -973,6 +974,7 @@ class POVFullscanStrategy(POVBaseStrategy):
                 task_id=self.task_id,
                 worker_id=f"Func_{index}_{self.fuzzer}_{self.sanitizer}",
                 log_dir=agent_log_dir,
+                index=index,  # For log file naming: SPG_{index}_{function_name}.log
             )
 
         try:
@@ -990,44 +992,14 @@ class POVFullscanStrategy(POVBaseStrategy):
                 f"[{index + 1}/{total}] Done: {func.name} in {func_duration:.1f}s - {sp_status}"
             )
 
-            # Write log block
-            await self._write_function_log_v2(agent, direction_id, agent_log_dir)
+            # Note: Agent logs are now written directly to SPG_{index}_{function_name}.log
+            # No need for separate combined log file
 
             return result
 
         except Exception as e:
             self.log_error(f"[{index + 1}/{total}] Failed: {func.name} - {e}")
             return {"success": False, "error": str(e)}
-
-    async def _write_function_log_v2(
-        self,
-        agent,
-        direction_id: str,
-        agent_log_dir,
-    ) -> None:
-        """
-        Write function analysis log block to direction log file.
-        """
-        from pathlib import Path
-
-        if direction_id not in self._direction_log_locks:
-            self._direction_log_locks[direction_id] = asyncio.Lock()
-
-        lock = self._direction_log_locks[direction_id]
-
-        log_block = agent.get_log_block() if hasattr(agent, "get_log_block") else ""
-        if not log_block:
-            return
-
-        log_file = Path(agent_log_dir) / f"{direction_id}-functioncheck.log"
-
-        async with lock:
-            try:
-                with open(log_file, "a", encoding="utf-8") as f:
-                    f.write(log_block)
-                    f.write("\n")
-            except Exception as e:
-                self.log_warning(f"Failed to write function log: {e}")
 
     def _log_coverage_report(self, directions: List) -> None:
         """

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
@@ -1089,17 +1089,16 @@ class POVFullscanStrategy(POVBaseStrategy):
         fuzzer_code = self._get_fuzzer_source_code()
         agent_log_dir = self.agent_log_dir
 
-        seeds_generated = 0
-
         # Generate seeds for each direction (high-risk first)
         sorted_directions = sorted(
             directions,
             key=lambda d: {"high": 0, "medium": 1, "low": 2}.get(d.risk_level, 3),
         )
 
-        for seed_index, direction in enumerate(sorted_directions[:5], start=1):  # Top 5 directions
+        # Create tasks for parallel execution (top 5 directions)
+        async def run_seed_agent(seed_index: int, direction) -> dict:
+            """Run a single SeedAgent and return result."""
             try:
-                # Create SeedAgent for this direction
                 seed_agent = SeedAgent(
                     task_id=self.task_id,
                     worker_id=self.worker_id,
@@ -1110,29 +1109,43 @@ class POVFullscanStrategy(POVBaseStrategy):
                     repos=self.repos,
                     fuzzer_source=fuzzer_code,
                     log_dir=agent_log_dir,
-                    max_iterations=20,  # Same as DirectionPlanningAgent
+                    max_iterations=20,
                     index=seed_index,
                     target_name=direction.name,
                 )
 
-                # Generate Direction Seeds
                 result = await seed_agent.generate_direction_seeds(
                     direction_id=direction.direction_id,
                     target_functions=direction.core_functions or [],
                     risk_level=direction.risk_level,
                     risk_reason=direction.risk_reason or "",
                 )
-
-                if result.get("success"):
-                    seeds_generated += result.get("seeds_generated", 0)
-                    self.log_info(
-                        f"  Generated {result.get('seeds_generated', 0)} seeds "
-                        f"for direction: {direction.name} ({direction.risk_level})"
-                    )
+                return {"direction": direction, "result": result}
 
             except Exception as e:
                 self.log_warning(
                     f"  Failed to generate seeds for {direction.name}: {e}"
+                )
+                return {"direction": direction, "result": None, "error": str(e)}
+
+        # Run all SeedAgents in parallel
+        tasks = [
+            run_seed_agent(idx, d)
+            for idx, d in enumerate(sorted_directions[:5], start=1)
+        ]
+        results = await asyncio.gather(*tasks)
+
+        # Collect results
+        seeds_generated = 0
+        for item in results:
+            direction = item["direction"]
+            result = item.get("result")
+            if result and result.get("success"):
+                count = result.get("seeds_generated", 0)
+                seeds_generated += count
+                self.log_info(
+                    f"  Generated {count} seeds "
+                    f"for direction: {direction.name} ({direction.risk_level})"
                 )
 
         self.log_info(

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_fullscan.py
@@ -140,7 +140,7 @@ class POVFullscanStrategy(POVBaseStrategy):
 
         self.log_info(f"Fuzzer: {self.fuzzer}, Reachable functions: {reachable_count}")
 
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
         planning_agent = DirectionPlanningAgent(
             fuzzer=self.fuzzer,
             sanitizer=self.sanitizer,
@@ -178,7 +178,7 @@ class POVFullscanStrategy(POVBaseStrategy):
 
         self.log_info(f"Fuzzer: {self.fuzzer}, Reachable functions: {reachable_count}")
 
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
         planning_agent = DirectionPlanningAgent(
             fuzzer=self.fuzzer,
             sanitizer=self.sanitizer,
@@ -297,7 +297,7 @@ class POVFullscanStrategy(POVBaseStrategy):
 
         # Get fuzzer code for all agents (SP Find + Verify)
         fuzzer_code = self._get_fuzzer_source_code()
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
 
         # Configure pipeline
         config = PipelineConfig(
@@ -319,7 +319,7 @@ class POVFullscanStrategy(POVBaseStrategy):
             scan_mode="full",  # Full-scan mode: use full reachability analysis
             config=config,
             output_dir=self.results_path / "povs",
-            log_dir=self.log_dir / "agent" if self.log_dir else self.results_path,
+            log_dir=self.agent_log_dir,
             workspace_path=self.workspace_path,
             fuzzer_code=fuzzer_code,
             mcp_socket_path=self.executor.analysis_socket_path,
@@ -405,7 +405,7 @@ class POVFullscanStrategy(POVBaseStrategy):
         self.log_info(f"Fuzzer: {self.fuzzer}, Reachable functions: {reachable_count}")
 
         # Create and run Direction Planning Agent
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
         planning_agent = DirectionPlanningAgent(
             fuzzer=self.fuzzer,
             sanitizer=self.sanitizer,
@@ -525,7 +525,7 @@ class POVFullscanStrategy(POVBaseStrategy):
         if self.executor.analysis_socket_path:
             set_analyzer_context(
                 self.executor.analysis_socket_path,
-                client_id=f"{self.worker_id}_sp_agent_{index}",
+                client_id=f"SPG_{index}_{self.fuzzer}_{self.sanitizer}",
             )
 
         direction_start = time.time()
@@ -538,7 +538,7 @@ class POVFullscanStrategy(POVBaseStrategy):
         claimed = self.repos.directions.claim(
             self.task_id,
             self.fuzzer,
-            f"{self.worker_id}_sp_agent_{index}",
+            f"SPG_{index}_{self.fuzzer}_{self.sanitizer}",
         )
         if not claimed:
             self.log_warning(f"[{index + 1}/{total}] Could not claim: {direction.name}")
@@ -556,7 +556,7 @@ class POVFullscanStrategy(POVBaseStrategy):
             code_summary=direction.code_summary,
             fuzzer_code=fuzzer_code,
             task_id=self.task_id,
-            worker_id=f"{self.worker_id}_agent_{index}",
+            worker_id=f"SPG_{index}_{self.fuzzer}_{self.sanitizer}",
             log_dir=agent_log_dir,
             max_iterations=100,
             index=index + 1,  # 1-based index for log files
@@ -668,7 +668,7 @@ class POVFullscanStrategy(POVBaseStrategy):
             )
 
         fuzzer_code = self._get_fuzzer_source_code()
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
 
         # Configure pipeline for verification and POV
         config = PipelineConfig(
@@ -689,7 +689,7 @@ class POVFullscanStrategy(POVBaseStrategy):
             scan_mode="full",  # Full-scan mode: use full reachability analysis
             config=config,
             output_dir=self.results_path / "povs",
-            log_dir=self.log_dir / "agent" if self.log_dir else self.results_path,
+            log_dir=self.agent_log_dir,
             workspace_path=self.workspace_path,
             fuzzer_code=fuzzer_code,
             mcp_socket_path=self.executor.analysis_socket_path,
@@ -955,7 +955,7 @@ class POVFullscanStrategy(POVBaseStrategy):
                 model=CLAUDE_OPUS_4_5,  # Force Opus for large function analysis
                 direction_id=direction_id,
                 task_id=self.task_id,
-                worker_id=f"{self.worker_id}_func_{index}",
+                worker_id=f"Func_{index}_{self.fuzzer}_{self.sanitizer}",
                 log_dir=agent_log_dir,
             )
         else:
@@ -971,7 +971,7 @@ class POVFullscanStrategy(POVBaseStrategy):
                 model=CLAUDE_SONNET_4_5,  # Force Sonnet for function analysis
                 direction_id=direction_id,
                 task_id=self.task_id,
-                worker_id=f"{self.worker_id}_func_{index}",
+                worker_id=f"Func_{index}_{self.fuzzer}_{self.sanitizer}",
                 log_dir=agent_log_dir,
             )
 
@@ -1087,7 +1087,7 @@ class POVFullscanStrategy(POVBaseStrategy):
         self.log_info("=== Generating Direction Seeds ===")
 
         fuzzer_code = self._get_fuzzer_source_code()
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
 
         seeds_generated = 0
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_strategy.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_strategy.py
@@ -70,7 +70,7 @@ class POVStrategy(BaseStrategy):
 
         # Create the suspicious point agent with logging context
         # Agent logs go to main log directory under agent/ subdirectory
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
         self._agent = SuspiciousPointAgent(
             fuzzer=self.fuzzer,
             sanitizer=self.sanitizer,
@@ -405,7 +405,7 @@ class POVStrategy(BaseStrategy):
         self.log_info(f"Fuzzer: {self.fuzzer}, Reachable functions: {reachable_count}")
 
         # Create and run Direction Planning Agent
-        agent_log_dir = self.log_dir / "agent" if self.log_dir else self.results_path
+        agent_log_dir = self.agent_log_dir
         planning_agent = DirectionPlanningAgent(
             fuzzer=self.fuzzer,
             sanitizer=self.sanitizer,
@@ -1027,7 +1027,7 @@ class POVStrategy(BaseStrategy):
         claimed = self.repos.directions.claim(
             self.task_id,
             self.fuzzer,
-            f"{self.worker_id}_sp_agent_{index}",
+            f"SPG_{index}_{self.fuzzer}_{self.sanitizer}",
         )
         if not claimed:
             self.log_warning(f"[{index + 1}/{total}] Could not claim: {direction.name}")
@@ -1044,7 +1044,7 @@ class POVStrategy(BaseStrategy):
             code_summary=direction.code_summary,
             fuzzer_code=fuzzer_code,
             task_id=self.task_id,
-            worker_id=f"{self.worker_id}_agent_{index}",
+            worker_id=f"SPG_{index}_{self.fuzzer}_{self.sanitizer}",
             log_dir=agent_log_dir,
             max_iterations=100,
             index=index + 1,  # 1-based index for log files
@@ -1409,7 +1409,7 @@ class POVStrategy(BaseStrategy):
             sanitizer=self.sanitizer,
             config=config,
             output_dir=self.povs_path,
-            log_dir=self.log_dir / "agent" if self.log_dir else None,
+            log_dir=self.agent_log_dir,
             workspace_path=self.workspace_path,
             worker_id=self.worker_id,  # For SP Fuzzer lifecycle
             fuzzer_code=fuzzer_code,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_strategy.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_strategy.py
@@ -62,9 +62,6 @@ class POVStrategy(BaseStrategy):
         # Reachability result (populated in delta mode)
         self._reachability_result: Optional[DiffReachabilityResult] = None
 
-        # SP Find v2: Locks for concurrent log writing (one per direction)
-        self._direction_log_locks: Dict[str, asyncio.Lock] = {}
-
         # Set up tool contexts for MCP
         self._setup_tool_contexts()
 
@@ -869,6 +866,7 @@ class POVStrategy(BaseStrategy):
                 worker_id=f"{self.worker_id}_func_{index}",
                 log_dir=agent_log_dir,
                 max_iterations=6,  # More iterations for large functions
+                index=index,  # For log file naming: SPG_{index}_{function_name}.log
             )
         else:
             agent = FunctionAnalysisAgent(
@@ -887,6 +885,7 @@ class POVStrategy(BaseStrategy):
                 worker_id=f"{self.worker_id}_func_{index}",
                 log_dir=agent_log_dir,
                 max_iterations=5,  # Enough iterations for thorough analysis
+                index=index,  # For log file naming: SPG_{index}_{function_name}.log
             )
 
         try:
@@ -904,53 +903,11 @@ class POVStrategy(BaseStrategy):
                 f"[{index + 1}/{total}] Done: {func.name} in {func_duration:.1f}s - {sp_status}"
             )
 
-            # Write log block to direction log file
-            await self._write_function_log(agent, direction_id, agent_log_dir)
-
             return result
 
         except Exception as e:
             self.log_error(f"[{index + 1}/{total}] Failed: {func.name} - {e}")
             return {"success": False, "error": str(e)}
-
-    async def _write_function_log(
-        self,
-        agent,
-        direction_id: str,
-        agent_log_dir,
-    ) -> None:
-        """
-        Write function analysis log block to direction log file.
-
-        Uses lock to prevent concurrent writes from corrupting the file.
-
-        Args:
-            agent: FunctionAnalysisAgent instance
-            direction_id: Direction ID for log file naming
-            agent_log_dir: Log directory
-        """
-        from pathlib import Path
-
-        # Get or create lock for this direction
-        if direction_id not in self._direction_log_locks:
-            self._direction_log_locks[direction_id] = asyncio.Lock()
-
-        lock = self._direction_log_locks[direction_id]
-
-        # Get formatted log block from agent
-        log_block = agent.get_log_block()
-
-        # Determine log file path
-        log_dir = Path(agent_log_dir) if agent_log_dir else self.results_path
-        log_file = log_dir / f"{direction_id}-functioncheck.log"
-
-        # Write with lock to prevent interleaving
-        async with lock:
-            try:
-                with open(log_file, "a", encoding="utf-8") as f:
-                    f.write(log_block)
-            except Exception as e:
-                self.log_error(f"Failed to write function log: {e}")
 
     async def _run_parallel_sp_find_agents_legacy(
         self,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_strategy.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_strategy.py
@@ -1047,6 +1047,7 @@ class POVStrategy(BaseStrategy):
             worker_id=f"{self.worker_id}_agent_{index}",
             log_dir=agent_log_dir,
             max_iterations=100,
+            index=index + 1,  # 1-based index for log files
         )
 
         try:


### PR DESCRIPTION
## Summary
- Fix parallel SeedAgent context collision causing Seeds Generated: 0
- Fix budget/timeout showing FAILED instead of COMPLETED
- Fix FunctionAnalysisAgent log paths: now `SPG_{index}_{function_name}.log`
- Remove redundant combined log files (`_write_function_log`)
- Fix cost API endpoint for summary display
- Add "interrupted" status for workers killed by timeout but with results
- Fix Celery soft timeout: now 90% of hard timeout (was causing premature worker termination)

## Changes
- `fuzzingbrain/fuzzer/seed_agent.py`: unique `_context_id` per instance
- `fuzzingbrain/agents/base.py`: add `mcp_context_id` property, `stop_reason` field
- `fuzzingbrain/agents/pov_agent.py`: graceful completion status display
- `fuzzingbrain/agents/function_analysis_agent.py`: pass logging params to base
- `fuzzingbrain/worker/strategies/pov_fullscan.py`: remove `_write_function_log_v2`
- `fuzzingbrain/worker/strategies/pov_strategy.py`: remove `_write_function_log`
- `fuzzingbrain/core/logging.py`: add timestamp conflict handling, interrupted status
- `fuzzingbrain/core/dispatcher.py`: fix soft timeout formula, add interrupted status
- `fuzzingbrain/core/task_processor.py`: fix cost API endpoint

## Test plan
- [x] Lint passed
- [ ] Run full pipeline with 10-15 min timeout
- [ ] Verify SPG logs have correct naming
- [ ] Verify cost displays correctly in summary
- [ ] Verify interrupted workers show ⚡ symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)