### PR TITLE
fix: SP agent urgency messages for find mode

### DIFF
--- a/FuzzingBrain-v2/v2/docs/issues-20260206.md
+++ b/FuzzingBrain-v2/v2/docs/issues-20260206.md
@@ -93,11 +93,69 @@ All 5 parallel SeedAgents used the **same** `worker_id` as context key, causing 
 
 ---
 
+## Issue 5: Summary显示Cost为$0.05而非实际值
+
+**Symptoms**:
+- Summary显示 `API Cost: $0.05` 但实际花费了 $13+
+
+**Root Cause**:
+- task_processor.py调用了错误的API endpoint
+- 调用: `/api/tasks/{task_id}`
+- 正确: `/api/v1/costs/task/{task_id}`
+
+**Fix**: Commit `0a7168396`
+- 修正API endpoint路径
+
+**Status**: FIXED
+
+---
+
+## Issue 6: 有POV但Worker显示Failed
+
+**Symptoms**:
+- Worker找到了4个POV
+- 但Summary显示 `0/1 completed, 1 failed`
+
+**Root Cause**:
+- Timeout时Celery强制终止worker
+- `result.failed()` 返回True
+- Worker被标记为failed，尽管已有成果
+
+**Fix**: Commit `0a7168396`
+- 新增 "interrupted" 状态
+- 有结果(SPs或POVs)但被杀的worker显示为 `⚡ interrupted`
+
+**Status**: FIXED
+
+---
+
+## Issue 7: Worker在Timeout前5分钟被杀
+
+**Symptoms**:
+- 设置10分钟timeout
+- Worker在5分钟时被 `SoftTimeLimitExceeded` 杀掉
+
+**Root Cause**:
+- Celery soft_timeout公式: `max(timeout - 300, timeout // 2)`
+- 10分钟: `max(600-300, 300) = 300秒 = 5分钟`
+- Worker只能运行50%的分配时间
+
+**Fix**: Commit `6a84e696c`
+- 改为: `soft_timeout = int(timeout * 0.9)`
+- 90%时间工作，10%用于graceful shutdown
+
+**Status**: FIXED
+
+---
+
 ## Summary
 
 | # | Issue | Priority | Status |
 |---|-------|----------|--------|
 | 1 | SeedAgent 0 seeds (parallel context collision) | Medium | FIXED (011595224) |
 | 2 | Budget exceeded status | Low | FIXED (652d7f650) |
-| 3 | SPG/SPV inconsistency - wrong log paths | High | FIXED |
-| 4 | Unknown combined log file | Medium | FIXED |
+| 3 | SPG/SPV inconsistency - wrong log paths | High | FIXED (597a645a0) |
+| 4 | Unknown combined log file | Medium | FIXED (597a645a0) |
+| 5 | Cost显示$0.05错误 | High | FIXED (0a7168396) |
+| 6 | 有POV但显示Failed | Medium | FIXED (0a7168396) |
+| 7 | Soft timeout过早杀worker | Critical | FIXED (6a84e696c) |


### PR DESCRIPTION
## Summary
- Enable urgency messages for SP agent find mode (was verify mode only)
- Change fixed thresholds to dynamic fractions based on max_iterations
- Add find-mode specific prompts to encourage saving discoveries before time runs out

## Changes
- `URGENCY_REMINDER_FRACTION = 0.2` (20% remaining → reminder)
- `URGENCY_FINAL_FRACTION = 0.1` (10% remaining → final warning)
- `_should_skip_urgency_message()`: find mode no longer skipped
- `_build_reminder_message()`: mode-specific prompts
- `_build_final_warning_message()`: mode-specific prompts

## Example
For 50 iterations:
- Iteration 40: "⏰ REMINDER: 10 iterations remaining..."
- Iteration 45+: "⚠️ FINAL: Only X iteration(s) left!"

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)