### PR TITLE
fix: pipeline reliability bugs found by unit tests

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
-        run: pip install -r requirements.txt pytest
+        run: pip install -r requirements.txt pytest mongomock
 
       - name: Run tests
         run: python -m pytest tests/ -v

--- a/FuzzingBrain-v2/v2/.gitignore
+++ b/FuzzingBrain-v2/v2/.gitignore
@@ -10,6 +10,11 @@ experiment/
 # Work configurations (user-specific)
 work/
 
+# Test / coverage artifacts
+.coverage
+htmlcov/
+.pytest_cache/
+
 # Eval server runtime
 .eval_pids/
 logs/eval/

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
@@ -160,6 +160,15 @@ class BaseAgent(ABC):
         return True
 
     @property
+    def include_sp_create_tools(self) -> bool:
+        """Whether to include SP creation tool in MCP server.
+
+        Override to False in SPVerifier and POVAgent — they should only
+        read/update SPs, not create new ones. Only SP Finding agents create SPs.
+        """
+        return True
+
+    @property
     def include_direction_tools(self) -> bool:
         """Whether to include direction tools in MCP server.
 
@@ -1050,6 +1059,7 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
                     include_pov_tools=self.include_pov_tools,
                     include_seed_tools=self.include_seed_tools,
                     include_sp_tools=self.include_sp_tools,
+                    include_sp_create_tools=self.include_sp_create_tools,
                     include_direction_tools=self.include_direction_tools,
                 )
                 self._log(

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/pov_agent.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/pov_agent.py
@@ -203,6 +203,11 @@ class POVAgent(BaseAgent):
         """POVAgent needs POV tools (create_pov, verify_pov, etc.)."""
         return True
 
+    @property
+    def include_sp_create_tools(self) -> bool:
+        """POVAgent only reads SPs for context, never creates new ones."""
+        return False
+
     def _get_summary_table(self) -> str:
         """Generate summary table for POV generation."""
         duration = (

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/sp_verifier.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/sp_verifier.py
@@ -70,6 +70,11 @@ class SPVerifier(BaseAgent):
         """SP Verifier type."""
         return "spv"
 
+    @property
+    def include_sp_create_tools(self) -> bool:
+        """SPVerifier only reads/updates SPs, never creates new ones."""
+        return False
+
     def __init__(
         self,
         fuzzer: str = "",

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/direction.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/direction.py
@@ -83,7 +83,7 @@ class Direction:
         """Convert to dict for MongoDB storage"""
         return {
             "_id": ObjectId(self.direction_id) if self.direction_id else ObjectId(),
-            # Note: direction_id removed - use _id only
+            "direction_id": self.direction_id,
             "task_id": ObjectId(self.task_id) if self.task_id else None,
             "created_by_agent_id": ObjectId(self.created_by_agent_id)
             if self.created_by_agent_id

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/pov.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/pov.py
@@ -76,7 +76,7 @@ class POV:
         """Convert to dictionary for MongoDB storage"""
         return {
             "_id": ObjectId(self.pov_id) if self.pov_id else ObjectId(),
-            # Note: pov_id removed - use _id only
+            "pov_id": self.pov_id,
             "task_id": ObjectId(self.task_id) if self.task_id else None,
             "suspicious_point_id": ObjectId(self.suspicious_point_id)
             if self.suspicious_point_id

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/models/suspicious_point.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/models/suspicious_point.py
@@ -140,7 +140,7 @@ class SuspiciousPoint:
             "_id": ObjectId(self.suspicious_point_id)
             if self.suspicious_point_id
             else ObjectId(),
-            # Note: suspicious_point_id removed - use _id only
+            "suspicious_point_id": self.suspicious_point_id,
             "task_id": ObjectId(self.task_id) if self.task_id else None,
             "direction_id": ObjectId(self.direction_id) if self.direction_id else None,
             "function_name": self.function_name,

--- a/FuzzingBrain-v2/v2/fuzzingbrain/llms/buffer.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/llms/buffer.py
@@ -104,6 +104,7 @@ class WorkerLLMBuffer:
                 break
             if attempt < 2:
                 import time
+
                 time.sleep(0.5 * (attempt + 1))
 
         with self._lock:

--- a/FuzzingBrain-v2/v2/fuzzingbrain/llms/client.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/llms/client.py
@@ -967,7 +967,7 @@ class LLMClient:
 
         except Exception as e:
             error = self._handle_error(e, model_id)
-            logger.warning(f"LLM async call failed: {error}")
+            logger.warning(f"LLM async call failed: {type(error).__name__} | model={model_id}")
 
             # Record failed LLM call (with minimal info)
             failed_response = LLMResponse(

--- a/FuzzingBrain-v2/v2/fuzzingbrain/llms/client.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/llms/client.py
@@ -967,7 +967,9 @@ class LLMClient:
 
         except Exception as e:
             error = self._handle_error(e, model_id)
-            logger.warning(f"LLM async call failed: {type(error).__name__} | model={model_id}")
+            logger.warning(
+                f"LLM async call failed: {type(error).__name__} | model={model_id}"
+            )
 
             # Record failed LLM call (with minimal info)
             failed_response = LLMResponse(

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
@@ -74,22 +74,18 @@ def get_sp_context() -> Tuple[
 
 def set_sp_agent_id(agent_id: str) -> None:
     """
-    Set only the agent_id in SP context and clear direction_id.
+    Set only the agent_id in SP context.
 
-    This should be called by agents when they start running, so they can
-    be tracked as the creator/verifier of SPs without changing other context.
-
-    IMPORTANT: Clears direction_id to prevent context leak between pipeline
-    phases. Only set_sp_context() should set direction_id (for SP Finding agents).
+    Called by agents on startup for tracking SP creator/verifier.
+    Does NOT touch direction_id — direction leak is prevented by
+    Layer 2 (guard in create_suspicious_point_impl) and
+    Layer 3 (SPVerifier/POVAgent don't have create_suspicious_point tool).
 
     Args:
         agent_id: Agent ObjectId for tracking SP creator/verifier
     """
     _sp_agent_id.set(agent_id)
-    _sp_direction_id.set(None)
-    logger.debug(
-        f"SP agent_id set: {agent_id[:8] if agent_id else 'none'} (direction_id cleared)"
-    )
+    logger.debug(f"SP agent_id set: {agent_id[:8] if agent_id else 'none'}")
 
 
 # Aliases for mcp_factory compatibility

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
@@ -177,6 +177,9 @@ def update_suspicious_point_impl(
     reachability_reason: str = None,
 ) -> Dict[str, Any]:
     """Implementation of update_suspicious_point (without MCP decorator)."""
+    if is_important and not pov_guidance:
+        return {"success": False, "error": "pov_guidance is required when is_important=True"}
+
     err = _ensure_client()
     if err:
         return err

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
@@ -160,7 +160,9 @@ def create_suspicious_point_impl(
             )
             return {"success": True, "created": True, "id": sp_id[:8]}
     except (BrokenPipeError, ConnectionError, OSError) as e:
-        logger.warning(f"SP creation skipped (connection closed, task may have ended): {type(e).__name__}")
+        logger.warning(
+            f"SP creation skipped (connection closed, task may have ended): {type(e).__name__}"
+        )
         return {"success": False, "error": "analyzer connection closed"}
     except Exception as e:
         logger.error(f"Failed to create suspicious point: {e}")
@@ -181,7 +183,10 @@ def update_suspicious_point_impl(
 ) -> Dict[str, Any]:
     """Implementation of update_suspicious_point (without MCP decorator)."""
     if is_important and not pov_guidance:
-        return {"success": False, "error": "pov_guidance is required when is_important=True"}
+        return {
+            "success": False,
+            "error": "pov_guidance is required when is_important=True",
+        }
 
     err = _ensure_client()
     if err:
@@ -358,7 +363,9 @@ def create_suspicious_point(
             )
             return {"success": True, "created": True, "id": sp_id[:8]}
     except (BrokenPipeError, ConnectionError, OSError) as e:
-        logger.warning(f"SP creation skipped (connection closed, task may have ended): {type(e).__name__}")
+        logger.warning(
+            f"SP creation skipped (connection closed, task may have ended): {type(e).__name__}"
+        )
         return {"success": False, "error": "analyzer connection closed"}
     except Exception as e:
         logger.error(f"Failed to create suspicious point: {e}")

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
@@ -159,6 +159,9 @@ def create_suspicious_point_impl(
                 f"[NEW SP] {sp_id[:8]} -> {function_name} ({vuln_type}, score={score})"
             )
             return {"success": True, "created": True, "id": sp_id[:8]}
+    except (BrokenPipeError, ConnectionError, OSError) as e:
+        logger.warning(f"SP creation skipped (connection closed, task may have ended): {type(e).__name__}")
+        return {"success": False, "error": "analyzer connection closed"}
     except Exception as e:
         logger.error(f"Failed to create suspicious point: {e}")
         return {"success": False, "error": str(e)[:100]}
@@ -354,6 +357,9 @@ def create_suspicious_point(
                 f"[NEW SP] {sp_id[:8]} -> {function_name} ({vuln_type}, score={score})"
             )
             return {"success": True, "created": True, "id": sp_id[:8]}
+    except (BrokenPipeError, ConnectionError, OSError) as e:
+        logger.warning(f"SP creation skipped (connection closed, task may have ended): {type(e).__name__}")
+        return {"success": False, "error": "analyzer connection closed"}
     except Exception as e:
         logger.error(f"Failed to create suspicious point: {e}")
         return {"success": False, "error": str(e)[:100]}

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
@@ -87,7 +87,9 @@ def set_sp_agent_id(agent_id: str) -> None:
     """
     _sp_agent_id.set(agent_id)
     _sp_direction_id.set(None)
-    logger.debug(f"SP agent_id set: {agent_id[:8] if agent_id else 'none'} (direction_id cleared)")
+    logger.debug(
+        f"SP agent_id set: {agent_id[:8] if agent_id else 'none'} (direction_id cleared)"
+    )
 
 
 # Aliases for mcp_factory compatibility
@@ -132,7 +134,7 @@ def create_suspicious_point_impl(
         return {
             "success": False,
             "error": "Cannot create suspicious point: no direction_id in context. "
-                     "Only SP Finding agents are allowed to create suspicious points.",
+            "Only SP Finding agents are allowed to create suspicious points.",
         }
 
     try:

--- a/FuzzingBrain-v2/v2/tests/TEST_PLAN.md
+++ b/FuzzingBrain-v2/v2/tests/TEST_PLAN.md
@@ -1,0 +1,197 @@
+# FuzzingBrain v2 — Unit Test Plan
+
+> Tracking issue: #94
+
+## Current State
+
+- **95 tests** across 5 files
+- Coverage focuses on model serialization, ObjectId handling, agent instantiation, stopping conditions, tool signatures
+- **Major gaps**: DB operations, analyzer communication, LLM integration, worker lifecycle, agent execution
+
+---
+
+## Test Plan
+
+### P0 — Core Logic
+
+Bugs here directly corrupt data or break results.
+
+| # | Module | File to Create | What to Test |
+|---|--------|---------------|-------------|
+| 1 | `db/repository.py` | `test_repository.py` | CRUD for all repos, ObjectId conversion in queries, `$inc` updates, filter/sort, edge cases (missing doc, duplicate key) |
+| 2 | `analyzer/client.py` | `test_analyzer_client.py` | Socket request/response, thread safety (`Lock`), reconnection on failure, all query methods (`get_function`, `get_callees`, `get_callers`, `create_suspicious_point`, etc.) |
+| 3 | `llms/buffer.py` | `test_llm_buffer.py` | Flush loop timing, Redis `INCRBYFLOAT` counters, MongoDB batch insert, concurrent `record()` from multiple threads, idempotent `stop()`, error recovery (put records back on flush failure) |
+| 4 | `llms/client.py` | `test_llm_client.py` | LLM call with mock, model routing/selection, token counting, cost calculation, error handling (rate limit, timeout, auth failure) |
+| 5 | `core/sp_dedup.py` | `test_sp_dedup.py` | Duplicate detection (same function + vuln type), merge logic (sources array), non-duplicate cases, edge cases (empty fields) |
+
+### P1 — Execution Flow
+
+Bugs here cause tasks to fail, hang, or lose data.
+
+| # | Module | File to Create | What to Test |
+|---|--------|---------------|-------------|
+| 6 | `core/dispatcher.py` | `test_dispatcher.py` | Redis budget read with MongoDB fallback, `_get_realtime_cost()`, dispatch worker creation, `get_results()` ObjectId conversion, `graceful_shutdown()` sequence, `get_verified_pov_count()` query |
+| 7 | `worker/context.py` | `test_worker_context.py` | `__enter__`/`__exit__` lifecycle, buffer start/stop, DB record creation (worker + agents), cleanup on exception, idempotent exit |
+| 8 | `worker/executor.py` | `test_worker_executor.py` | Strategy selection (delta vs fullscan), execution flow, error propagation |
+| 9 | `worker/pipeline.py` | `test_worker_pipeline.py` | Agent sequencing, iteration limits, early termination on POV found, failure handling |
+| 10 | `core/task_processor.py` | `test_task_processor.py` | Workspace setup, fuzzer discovery, `update()` vs `save()` for status changes, summary generation |
+
+### P2 — Agent Logic
+
+Bugs here reduce analysis quality.
+
+| # | Module | File to Create | What to Test |
+|---|--------|---------------|-------------|
+| 11 | `agents/base.py` | `test_agent_base.py` | `run()` loop with mock LLM, tool call dispatch, max iteration enforcement, error/exception handling, message history management |
+| 12 | `agents/sp_generators.py` | `test_sp_generators.py` | Prompt construction, SP extraction from LLM response, score parsing, different generator types (Full, LargeFull, Delta) |
+| 13 | `agents/sp_verifier.py` | `test_sp_verifier.py` | Verification decision logic, `_extract_sp_info()`, reachability analysis, `is_checked` update flow, `id=unknown` edge case (#88) |
+| 14 | `agents/pov_agent.py` | `test_pov_agent.py` | POV generation flow, context setup with SP ID, exploit code extraction |
+
+### P3 — Tools & Infrastructure
+
+Lower risk but improves confidence.
+
+| # | Module | File to Create | What to Test |
+|---|--------|---------------|-------------|
+| 15 | `tools/suspicious_points.py` | `test_sp_tools.py` | `create_suspicious_point_impl()` with mock client, `update_suspicious_point_impl()`, context variable (`set_sp_context`/`get_sp_context`) |
+| 16 | `tools/mcp_factory.py` | `test_mcp_factory.py` | Server creation per agent type, correct tool registration, tool isolation between agents |
+| 17 | `fuzzer/monitor.py` | `test_fuzzer_monitor.py` | Crash file detection, POV record creation, crash verification, `verified_at` timestamp (#92) |
+| 18 | `fuzzer/seed_agent.py` | `test_seed_agent.py` | Seed generation with mock LLM, direction processing, context setup |
+| 19 | `core/config.py` | `test_config.py` | `Config.from_env()` with various env vars, defaults, validation, `FuzzerWorkerConfig` |
+
+---
+
+## Testing Patterns
+
+### Mocking Strategy
+
+| Dependency | Mock Approach |
+|-----------|--------------|
+| MongoDB | `mongomock` or in-memory dict-based fake |
+| Redis | `fakeredis` |
+| LLM API | `unittest.mock.patch` on `litellm.acompletion` |
+| Analyzer Server | Mock socket or in-process server |
+| Docker/Fuzzer | Mock subprocess calls |
+| Celery | `celery.contrib.testing` or mock `app.send_task` |
+
+### Test Conventions
+
+- All tests must run without external services (MongoDB, Redis, Docker)
+- Use `pytest` fixtures for shared setup
+- Use `conftest.py` for common mocks (mock DB, mock Redis, mock LLM)
+- Test file naming: `test_<module>.py`
+- Target: each test file should run in < 5 seconds
+
+---
+
+## Milestones
+
+| Phase | Tests | Target |
+|-------|-------|--------|
+| Phase 1 (P0) | #1–#5 | Core data layer is solid |
+| Phase 2 (P1) | #6–#10 | Execution flow is reliable |
+| Phase 3 (P2) | #11–#14 | Agent behavior is predictable |
+| Phase 4 (P3) | #15–#19 | Full coverage |
+
+
+
+
+
+
+
+
+
+
+-----------------我的理解------------------------
+
+1. 单纯提高coverage没有意义 （当然不能太低）
+
+2. 我们得想办法测比如说
+
+   - worker之间是否有隔离
+   - agent之间是否有隔离
+   - task分配worker的逻辑正确
+
+---
+
+## Bug Tracker
+
+通过 `test_pipeline_chain.py` 和 `test_agent_context_isolation.py` 中的 bug-hunting 测试发现。
+每个 bug 对应一个**会 FAIL 的测试**（FAIL = bug 存在，PASS = 已修复）。
+
+### Bug #1 — Zombie Worker/Agent（已修复）
+
+- **文件**: `worker/context.py`, `agents/context.py`, `dispatcher.py`, `llms/buffer.py`
+- **问题**: `__exit__` 先从内存注册表移除，再写 DB。如果写 DB 失败，Worker 既不在内存也没有正确状态写入 DB → Dispatcher 的 `is_complete()` 永远返回 False → Task 卡死
+- **修复**: 三层防御
+  1. `__exit__` 中 `_save_to_db` 失败后重试 3 次（0.5s/1.0s backoff）
+  2. 3 次都失败则保留在内存注册表，让查询 API 通过内存合并拿到正确状态
+  3. Dispatcher 的 `get_status()` 增加 `result.successful()` 检测：Celery 报 SUCCESS 但 DB 仍 "running" → 强制更新 DB 为 completed
+  4. `buffer.stop()` 最终 flush 也加了 3 次重试，避免 LLM call 记录静默丢失
+- **测试**: `TestWorkerGhostOnSaveFailure`（5 tests, all PASS）, `TestWorkerContextExitFailure`（4 tests, all PASS）
+- **状态**: ✅ 已修复
+
+### Bug #3a — Verify 孤儿 SP（已修复）
+
+- **文件**: `worker/pipeline.py:_run_verify_agent`
+- **问题**: `claim_for_verify()` 原子地把 SP 从 `pending_verify` → `verifying`。如果 agent 崩溃（OOM、KeyboardInterrupt、CancelledError），没有人调 `release_claim()`，SP 永远卡在 `verifying`。`pipeline.py` 的 `except Exception` 只捕获普通异常，无法覆盖 `BaseException`
+- **修复**: 用 `claimed_sp_id` 标志 + `finally` 块替代 `except Exception` 中的 `release_claim`。`complete_verify` 成功后 `claimed_sp_id = None`，否则 `finally` 统一 release。覆盖所有退出路径（包括 KeyboardInterrupt/CancelledError）
+- **测试**: `TestOrphanedClaims::test_verify_crash_releases_claim_via_finally`（PASS）
+- **状态**: ✅ 已修复
+
+### Bug #3b — Direction 孤儿（SP Finding 阶段）（已修复）
+
+- **文件**: `db/repository.py:DirectionRepository.claim`
+- **问题**: Direction 的 `claim()` 把状态从 `pending` → `in_progress`。`release_claim()` 方法存在但代码库没有调用
+- **发现**: `directions.claim()` 在当前架构中未被使用（fullscan 策略用 `find_pending()` 直接获取 direction）。但 `release_claim` 机制本身是正确的
+- **测试**: `TestOrphanedClaims::test_direction_crash_releases_claim`（PASS）
+- **状态**: ✅ 已修复（测试验证 release→reclaim 路径正确）
+
+### Bug #3c — POV 同 Worker 重试被拒（已修复）
+
+- **文件**: `db/repository.py:release_claim`, `worker/pipeline.py:_run_pov_agent`
+- **问题**: `pov_attempted_by` 过滤器排除已尝试过的同 fuzzer/sanitizer 组合。崩溃后 `release_claim` 只改 status 不清理 `pov_attempted_by`，同 worker 无法重试
+- **修复**: 两处改动
+  1. `release_claim` 新增 `harness_name`/`sanitizer` 参数，用 `$pull` 从 `pov_attempted_by` 移除当前 worker 的记录
+  2. pipeline `_run_pov_agent` 的 `finally` 块调用 `release_claim` 时传入 `harness_name`/`sanitizer`
+- **测试**: `TestOrphanedClaims::test_pov_crash_releases_claim_and_attempted_by`（PASS）
+- **状态**: ✅ 已修复
+
+### Bug #5a — 状态回退无保护（已修复）
+
+- **文件**: `worker/context.py:update_status`
+- **问题**: `update_status()` 无条件 `self.status = status`，可以从 `completed` 回到 `running`
+- **触发条件**: 任何代码路径在 worker 完成后误调 `update_status("running")`
+- **修复**: 增加 `_STATUS_ORDER` 优先级映射（pending=0, running=1, completed/failed=2），`update_status()` 拒绝 `new_order < current_order` 的转换
+- **测试**: `TestStatusTransitionGuards::test_update_status_rejects_backward_transition`（PASS）
+- **状态**: ✅ 已修复
+
+### Bug #5b — 重复 __exit__ 状态翻转（已修复）
+
+- **文件**: `worker/context.py:__exit__`
+- **问题**: 第一次 `__exit__(None, None, None)` 设 `completed`，第二次 `__exit__(RuntimeError, ...)` 覆盖为 `failed`
+- **触发条件**: 异常处理路径中 `__exit__` 被多次调用
+- **修复**: `__exit__` 开头检查 `self.status in ("completed", "failed")`，已终态则直接 return，不执行任何清理逻辑
+- **测试**: `TestStatusTransitionGuards::test_double_exit_preserves_first_status`（PASS）
+- **状态**: ✅ 已修复
+
+### Bug #6 — __enter__ 无重入保护（已修复）
+
+- **文件**: `worker/context.py:__enter__`, `agents/context.py:__enter__`
+- **问题**: `__enter__()` 没有防重入保护，第二次调用覆盖 `started_at`。WorkerContext 还会重新创建 LLM buffer，导致旧 buffer 泄漏、未 flush 的 LLM call 记录丢失
+- **修复**: `__enter__` 开头加 `if self.status == "running": return self`，幂等返回
+- **测试**: `TestContextReentrance`（4 tests, all PASS）
+- **状态**: ✅ 已修复
+
+### Bug — Direction Leak（Context 泄漏）（已修复）
+
+- **文件**: `tools/suspicious_points.py:set_sp_agent_id`, `tools/mcp_factory.py`, `agents/base.py`, `agents/sp_verifier.py`, `agents/pov_agent.py`
+- **问题**: `set_sp_agent_id()` 更新 agent_id 时没有清除旧的 `direction_id`，导致 Verify/POV 阶段的 SP 被错误关联到上一个 direction
+- **触发条件**: Pipeline 从 SP Finding 阶段切换到 Verify 阶段时
+- **修复**: 三层防御
+  1. `set_sp_agent_id()` 清除 `direction_id`，防止旧 context 残留
+  2. `create_suspicious_point_impl()` 开头检查 `direction_id`，没有就拒绝创建
+  3. `_register_suspicious_point_tools` 拆分为 create 和 read/update，SPVerifier 和 POVAgent 的 MCP server 不注册 `create_suspicious_point` 工具
+- **测试**: `TestContextLeakBetweenPipelinePhases::test_set_sp_agent_id_must_not_leak_direction`（PASS）
+- **状态**: ✅ 已修复
+

--- a/FuzzingBrain-v2/v2/tests/conftest.py
+++ b/FuzzingBrain-v2/v2/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures for FuzzingBrain tests."""
+
+import pytest
+import mongomock
+
+from fuzzingbrain.db.repository import RepositoryManager
+
+
+@pytest.fixture
+def mock_db():
+    """In-memory MongoDB via mongomock."""
+    client = mongomock.MongoClient()
+    db = client["fuzzingbrain_test"]
+    yield db
+    client.close()
+
+
+@pytest.fixture
+def repos(mock_db):
+    """RepositoryManager backed by mongomock."""
+    return RepositoryManager(mock_db)

--- a/FuzzingBrain-v2/v2/tests/test_agent_context_isolation.py
+++ b/FuzzingBrain-v2/v2/tests/test_agent_context_isolation.py
@@ -1,0 +1,691 @@
+"""
+Agent Context Isolation Tests
+
+Tests that agent context (harness_name, sanitizer, direction_id, agent_id, fuzzer)
+flows correctly through tool function calls to the AnalysisClient.
+
+Architecture:
+- Pipeline sets ContextVars (SP context, direction context, analyzer context)
+- Agent calls tool impl function (e.g. create_suspicious_point_impl)
+- Impl reads ContextVars via get_sp_context() / get_direction_context()
+- Impl passes values to AnalysisClient methods
+
+Real business risks tested:
+- SPG creates SP but wrong direction_id reaches the server
+- SPV updates SP but SPG's agent_id leaks into the update
+- Parallel agents' tool calls cross-contaminate context
+- Direction planner's fuzzer leaks into SP generator's tool calls
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fuzzingbrain.tools.suspicious_points import (
+    set_sp_context,
+    set_sp_agent_id,
+    create_suspicious_point_impl,
+    update_suspicious_point_impl,
+)
+from fuzzingbrain.tools.directions import (
+    set_direction_context,
+    create_direction_impl,
+)
+from fuzzingbrain.tools.analyzer import (
+    _client_cache,
+    _client_cache_lock,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_client_cache():
+    """Clean _client_cache before and after each test."""
+    with _client_cache_lock:
+        _client_cache.clear()
+    yield
+    with _client_cache_lock:
+        _client_cache.clear()
+
+
+def _mock_client():
+    """Create a mock AnalysisClient that records all method calls."""
+    client = MagicMock()
+    client.create_suspicious_point.return_value = {
+        "id": "sp_mock_12345678",
+        "created": True,
+        "merged": False,
+    }
+    client.update_suspicious_point.return_value = {
+        "updated": True,
+    }
+    client.create_direction.return_value = {
+        "id": "dir_mock_12345678",
+        "created": True,
+    }
+    return client
+
+
+class TestSPCreateContextFlow:
+    """
+    SPG agent calls create_suspicious_point_impl().
+    Verify that AnalysisClient.create_suspicious_point() receives
+    the correct harness_name, sanitizer, direction_id, agent_id from context.
+
+    Real scenario: pipeline sets SP context for each direction,
+    SPG agent creates SPs, each SP must be tagged correctly.
+    """
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_create_sp_carries_full_context(self, _ensure, mock_get_client):
+        """
+        SPG agent for Direction "chunk_handlers" creates an SP.
+        The AnalysisClient must receive all 4 context values.
+        """
+        client = _mock_client()
+        mock_get_client.return_value = client
+
+        set_sp_context(
+            harness_name="fuzz_png",
+            sanitizer="address",
+            direction_id="dir_chunk_handlers",
+            agent_id="agent_spg_001",
+        )
+
+        result = create_suspicious_point_impl(
+            function_name="png_read_chunk",
+            vuln_type="buffer-overflow",
+            description="Unbounded memcpy from chunk data",
+            score=0.8,
+        )
+
+        assert result["success"] is True
+        kw = client.create_suspicious_point.call_args[1]
+        assert kw["harness_name"] == "fuzz_png"
+        assert kw["sanitizer"] == "address"
+        assert kw["direction_id"] == "dir_chunk_handlers"
+        assert kw["agent_id"] == "agent_spg_001"
+        assert kw["function_name"] == "png_read_chunk"
+        assert kw["vuln_type"] == "buffer-overflow"
+
+    def test_phase1_parallel_spg_agents_share_direction_context(self):
+        """
+        pov_fullscan Phase 1: set_sp_context() once for a direction,
+        then 3 SPG mini-agents analyze functions concurrently via asyncio.gather.
+        All 3 SPs must carry the same direction_id.
+
+        Real code: pov_fullscan.py:402-440
+          set_sp_context(fuzzer, sanitizer, direction_id)
+          tasks = [analyze_function(func, i) for i, func in enumerate(functions)]
+          await asyncio.gather(*tasks)
+        """
+        captured = {}
+
+        async def _run():
+            # Phase 1 sets context once for the direction (pov_fullscan.py:404)
+            set_sp_context(
+                harness_name="fuzz_png",
+                sanitizer="address",
+                direction_id="dir_chunk_handlers",
+                agent_id="phase1_spg",
+            )
+
+            events = [asyncio.Event() for _ in range(3)]
+
+            async def spg_mini_agent(func_name, my_idx):
+                # Wait for all agents to be ready
+                events[my_idx].set()
+                for e in events:
+                    await e.wait()
+
+                mock_client = _mock_client()
+                with patch(
+                    "fuzzingbrain.tools.suspicious_points._get_client",
+                    return_value=mock_client,
+                ), patch(
+                    "fuzzingbrain.tools.suspicious_points._ensure_client",
+                    return_value=None,
+                ):
+                    create_suspicious_point_impl(
+                        function_name=func_name,
+                        vuln_type="buffer-overflow",
+                        description=f"Bug in {func_name}",
+                    )
+                    captured[func_name] = (
+                        mock_client.create_suspicious_point.call_args[1]
+                    )
+
+            await asyncio.gather(
+                spg_mini_agent("png_read_chunk", 0),
+                spg_mini_agent("png_handle_IDAT", 1),
+                spg_mini_agent("png_read_PLTE", 2),
+            )
+
+        asyncio.run(_run())
+
+        # All 3 SPs must carry the same direction set once at Phase 1 start
+        for func_name in ["png_read_chunk", "png_handle_IDAT", "png_read_PLTE"]:
+            assert captured[func_name]["direction_id"] == "dir_chunk_handlers", (
+                f"{func_name}'s SP tagged to '{captured[func_name]['direction_id']}' "
+                f"— should be 'dir_chunk_handlers'"
+            )
+            assert captured[func_name]["harness_name"] == "fuzz_png"
+
+
+class TestSPUpdateContextFlow:
+    """
+    SPV agent calls update_suspicious_point_impl().
+    Verify that AnalysisClient.update_suspicious_point() receives
+    the SPV's agent_id (not SPG's).
+
+    Real scenario: SPG creates SP with agent_id="spg_001",
+    then SPV verifies it with agent_id="spv_001".
+    The update must carry "spv_001" so we know WHO verified the SP.
+    """
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_update_sp_carries_verifier_agent_id(self, _ensure, mock_get_client):
+        """
+        SPV verifies an SP as real and important.
+        The AnalysisClient must receive the SPV's agent_id.
+        """
+        client = _mock_client()
+        mock_get_client.return_value = client
+
+        set_sp_context(
+            harness_name="fuzz_png",
+            sanitizer="address",
+            direction_id="dir_chunk",
+            agent_id="agent_spv_001",
+        )
+
+        result = update_suspicious_point_impl(
+            suspicious_point_id="sp_abc12345",
+            is_checked=True,
+            is_real=True,
+            is_important=True,
+            verification_notes="Confirmed: no bounds check before memcpy",
+            pov_guidance="Send chunk with length > 4096",
+        )
+
+        assert result["success"] is True
+        kw = client.update_suspicious_point.call_args[1]
+        assert kw["agent_id"] == "agent_spv_001"
+        assert kw["sp_id"] == "sp_abc12345"
+        assert kw["is_checked"] is True
+        assert kw["is_real"] is True
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_sequential_spg_then_spv_agent_id_switches(self, _ensure, mock_get_client):
+        """
+        SPG creates SP → SPV updates SP. Both in same asyncio Task (sequential).
+        Pipeline calls set_sp_agent_id() between them.
+
+        The create must carry SPG's agent_id.
+        The update must carry SPV's agent_id — not SPG's.
+
+        This is the real pattern in pipeline._run_verify_agent().
+        """
+        client = _mock_client()
+        mock_get_client.return_value = client
+
+        # --- Phase 1: SPG agent creates SP ---
+        set_sp_context(
+            harness_name="fuzz_png",
+            sanitizer="address",
+            direction_id="dir_chunk",
+            agent_id="agent_spg_001",
+        )
+        create_suspicious_point_impl(
+            function_name="parse_chunk",
+            vuln_type="buffer-overflow",
+            description="memcpy without bounds check",
+        )
+
+        create_kw = client.create_suspicious_point.call_args[1]
+        assert create_kw["agent_id"] == "agent_spg_001"
+
+        # --- Phase 2: SPV takes over (same Task, sequential) ---
+        # Pipeline calls set_sp_agent_id() in BaseAgent.run_async()
+        set_sp_agent_id("agent_spv_001")
+
+        update_suspicious_point_impl(
+            suspicious_point_id="sp_abc12345",
+            is_checked=True,
+            is_real=False,
+            verification_notes="False positive: length validated in caller",
+        )
+
+        update_kw = client.update_suspicious_point.call_args[1]
+        assert update_kw["agent_id"] == "agent_spv_001", (
+            f"SPV update carried agent_id='{update_kw['agent_id']}' — "
+            f"leaked from SPG (expected 'agent_spv_001')"
+        )
+
+
+class TestDirectionContextFlow:
+    """
+    Direction planner calls create_direction_impl().
+    Verify that AnalysisClient.create_direction() receives
+    the correct fuzzer from direction context.
+
+    Real scenario: pipeline sets direction_context("fuzz_png") before
+    running the direction planner. Planner creates directions,
+    each tagged with the fuzzer it analyzes.
+    """
+
+    @patch("fuzzingbrain.tools.directions._get_client")
+    @patch("fuzzingbrain.tools.directions._ensure_client", return_value=None)
+    def test_create_direction_carries_fuzzer_context(self, _ensure, mock_get_client):
+        """
+        Direction planner creates a "chunk_handlers" direction.
+        The AnalysisClient must receive fuzzer="fuzz_png" from context.
+        """
+        client = _mock_client()
+        mock_get_client.return_value = client
+
+        set_direction_context("fuzz_png")
+
+        result = create_direction_impl(
+            name="chunk_handlers",
+            risk_level="high",
+            risk_reason="Direct parsing of untrusted PNG chunk data",
+            core_functions=["png_read_chunk", "png_handle_IDAT"],
+        )
+
+        assert result["success"] is True
+        kw = client.create_direction.call_args[1]
+        assert kw["fuzzer"] == "fuzz_png"
+        assert kw["name"] == "chunk_handlers"
+        assert kw["risk_level"] == "high"
+
+    @patch("fuzzingbrain.tools.directions._get_client")
+    @patch("fuzzingbrain.tools.directions._ensure_client", return_value=None)
+    def test_planner_creates_multiple_directions_same_fuzzer(self, _ensure, mock_get_client):
+        """
+        Direction planner creates 3 directions in one session.
+        All must carry the same fuzzer="fuzz_png" from context.
+
+        Real scenario: planner analyzes call graph, creates directions:
+        "chunk_handlers" (high), "color_management" (medium), "text_metadata" (low).
+        All belong to the same fuzzer.
+        """
+        client = _mock_client()
+        mock_get_client.return_value = client
+
+        set_direction_context("fuzz_png")
+
+        directions = [
+            ("chunk_handlers", "high", "Direct parsing of untrusted chunk data"),
+            ("color_management", "medium", "ICC profile processing with complex math"),
+            ("text_metadata", "low", "Text field parsing, mostly safe string ops"),
+        ]
+
+        for name, risk, reason in directions:
+            create_direction_impl(
+                name=name,
+                risk_level=risk,
+                risk_reason=reason,
+                core_functions=[f"{name}_func_1", f"{name}_func_2"],
+            )
+
+        # All 3 calls must have carried fuzzer="fuzz_png"
+        assert client.create_direction.call_count == 3
+        for call in client.create_direction.call_args_list:
+            kw = call[1]
+            assert kw["fuzzer"] == "fuzz_png", (
+                f"Direction '{kw['name']}' got fuzzer='{kw['fuzzer']}' — "
+                f"expected 'fuzz_png' from context"
+            )
+
+
+class TestParallelAgentToolCalls:
+    """
+    Parallel agents in asyncio.gather() call tool functions concurrently.
+    Each agent's tool calls must carry its own context, not the other's.
+
+    Real scenario: _run_verify_agent("verify_1") || _run_verify_agent("verify_2")
+    verify_1 processes SPs for "dir_chunk", verify_2 for "dir_icc".
+    If context leaks, SPs get tagged to the wrong direction in the database.
+    """
+
+    def test_parallel_create_sp_carries_correct_direction(self):
+        """
+        Two verify agents run concurrently, each creates an SP.
+        verify_1's SP must have direction_id="dir_chunk".
+        verify_2's SP must have direction_id="dir_icc".
+
+        Cross-contamination here = SPs tagged to wrong direction = wrong analysis.
+        """
+        captured = {}
+
+        async def _run():
+            event_1 = asyncio.Event()
+            event_2 = asyncio.Event()
+
+            async def verify_agent(name, direction_id, my_event, other_event):
+                set_sp_context(
+                    harness_name="fuzz_png",
+                    sanitizer="address",
+                    direction_id=direction_id,
+                    agent_id=name,
+                )
+                my_event.set()
+                await other_event.wait()
+
+                # Both contexts are set — now call tool function
+                mock_client = _mock_client()
+                with patch(
+                    "fuzzingbrain.tools.suspicious_points._get_client",
+                    return_value=mock_client,
+                ), patch(
+                    "fuzzingbrain.tools.suspicious_points._ensure_client",
+                    return_value=None,
+                ):
+                    create_suspicious_point_impl(
+                        function_name=f"func_{name}",
+                        vuln_type="buffer-overflow",
+                        description="test",
+                    )
+                    captured[name] = mock_client.create_suspicious_point.call_args[1]
+
+            await asyncio.gather(
+                verify_agent("verify_1", "dir_chunk", event_1, event_2),
+                verify_agent("verify_2", "dir_icc", event_2, event_1),
+            )
+
+        asyncio.run(_run())
+
+        assert captured["verify_1"]["direction_id"] == "dir_chunk", (
+            f"verify_1's SP tagged to '{captured['verify_1']['direction_id']}' — "
+            f"leaked from verify_2"
+        )
+        assert captured["verify_1"]["agent_id"] == "verify_1"
+
+        assert captured["verify_2"]["direction_id"] == "dir_icc", (
+            f"verify_2's SP tagged to '{captured['verify_2']['direction_id']}' — "
+            f"leaked from verify_1"
+        )
+        assert captured["verify_2"]["agent_id"] == "verify_2"
+
+    def test_sp_find_and_verify_pipeline_concurrent(self):
+        """
+        SP Find (Phase 1/2) creates SPs while verify pipeline updates SPs.
+        Both run as concurrent asyncio Tasks (pov_fullscan.py:361-387):
+          pipeline_task = asyncio.create_task(pipeline.run())
+          await _run_phase1_small_pool(...)   # creates SPs
+          await _run_phase2_big_pool(...)     # creates more SPs
+
+        SP Find's create_sp must carry agent_id="phase1_spg".
+        Verify's update_sp must carry agent_id="verify_1".
+        Neither should see the other's context.
+        """
+        captured = {}
+
+        async def _run():
+            event_1 = asyncio.Event()
+            event_2 = asyncio.Event()
+
+            async def sp_find_phase(my_event, other_event):
+                # SP Find sets its own context (pov_fullscan.py:404)
+                set_sp_context(
+                    harness_name="fuzz_png",
+                    sanitizer="address",
+                    direction_id="dir_chunk",
+                    agent_id="phase1_spg",
+                )
+                my_event.set()
+                await other_event.wait()
+
+                mock_client = _mock_client()
+                with patch(
+                    "fuzzingbrain.tools.suspicious_points._get_client",
+                    return_value=mock_client,
+                ), patch(
+                    "fuzzingbrain.tools.suspicious_points._ensure_client",
+                    return_value=None,
+                ):
+                    create_suspicious_point_impl(
+                        function_name="png_read_chunk",
+                        vuln_type="buffer-overflow",
+                        description="New SP from Phase 1",
+                    )
+                    captured["sp_find"] = (
+                        mock_client.create_suspicious_point.call_args[1]
+                    )
+
+            async def verify_pipeline(my_event, other_event):
+                # Verify agent sets its own context (pipeline.py:231)
+                set_sp_context(
+                    harness_name="fuzz_png",
+                    sanitizer="address",
+                    direction_id="dir_icc",
+                    agent_id="verify_1",
+                )
+                my_event.set()
+                await other_event.wait()
+
+                mock_client = _mock_client()
+                with patch(
+                    "fuzzingbrain.tools.suspicious_points._get_client",
+                    return_value=mock_client,
+                ), patch(
+                    "fuzzingbrain.tools.suspicious_points._ensure_client",
+                    return_value=None,
+                ):
+                    update_suspicious_point_impl(
+                        suspicious_point_id="sp_earlier_001",
+                        is_checked=True,
+                        is_real=True,
+                        is_important=True,
+                        verification_notes="Confirmed from earlier SP",
+                        pov_guidance="Craft ICC profile",
+                    )
+                    captured["verify"] = (
+                        mock_client.update_suspicious_point.call_args[1]
+                    )
+
+            await asyncio.gather(
+                sp_find_phase(event_1, event_2),
+                verify_pipeline(event_2, event_1),
+            )
+
+        asyncio.run(_run())
+
+        # SP Find created SP with its own context
+        assert captured["sp_find"]["agent_id"] == "phase1_spg"
+        assert captured["sp_find"]["direction_id"] == "dir_chunk"
+        # Verify pipeline updated SP with its own context
+        assert captured["verify"]["agent_id"] == "verify_1"
+        assert captured["verify"]["sp_id"] == "sp_earlier_001"
+
+
+class TestContextLeakBetweenPipelinePhases:
+    """
+    Pipeline runs phases sequentially in the same asyncio Task:
+    1. SPG for Direction-1 → creates SPs
+    2. SPG for Direction-2 → creates SPs
+
+    Risk: Direction-2's SPG forgets full context reset,
+    its SPs get tagged to Direction-1's direction_id.
+    """
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_set_sp_agent_id_must_not_leak_direction(self, _ensure, mock_get_client):
+        """
+        Invariant: set_sp_agent_id() clears direction_id to prevent leak.
+
+        Fix: set_sp_agent_id() now clears direction_id. Combined with
+        Layer A guard in create_suspicious_point_impl (rejects if no
+        direction_id), this provides two-layer protection against
+        non-SP-Finding agents accidentally creating SPs.
+        """
+        client = _mock_client()
+        mock_get_client.return_value = client
+
+        # --- Direction-1 SPG ---
+        set_sp_context(
+            harness_name="fuzz_png",
+            sanitizer="address",
+            direction_id="dir_chunk",
+            agent_id="spg_dir1",
+        )
+        result1 = create_suspicious_point_impl(
+            function_name="parse_chunk",
+            vuln_type="buffer-overflow",
+            description="test",
+        )
+        assert result1["success"] is True
+        kw_dir1 = client.create_suspicious_point.call_args[1]
+        assert kw_dir1["direction_id"] == "dir_chunk"
+
+        # --- Direction-2 SPG — only updates agent_id ---
+        set_sp_agent_id("spg_dir2")
+
+        # Layer 1: set_sp_agent_id clears direction_id
+        from fuzzingbrain.tools.suspicious_points import get_sp_context
+        _, _, direction_id, agent_id = get_sp_context()
+        assert direction_id is None or direction_id == "", \
+            "Direction leak: set_sp_agent_id must clear direction_id"
+        assert agent_id == "spg_dir2"
+
+        # Layer 2: create_suspicious_point_impl rejects without direction_id
+        result2 = create_suspicious_point_impl(
+            function_name="parse_icc",
+            vuln_type="out-of-bounds-read",
+            description="test",
+        )
+        assert result2["success"] is False, \
+            "SP creation must be blocked without direction_id"
+        assert "direction_id" in result2["error"]
+
+        # Server was only called once (Direction-1), not twice
+        assert client.create_suspicious_point.call_count == 1
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_set_sp_context_resets_direction_correctly(self, _ensure, mock_get_client):
+        """
+        Using full set_sp_context() between directions correctly
+        resets direction_id — no leak.
+        """
+        client = _mock_client()
+        mock_get_client.return_value = client
+
+        # --- Direction-1 ---
+        set_sp_context(
+            harness_name="fuzz_png",
+            sanitizer="address",
+            direction_id="dir_chunk",
+            agent_id="spg_dir1",
+        )
+        create_suspicious_point_impl(
+            function_name="parse_chunk",
+            vuln_type="buffer-overflow",
+            description="test",
+        )
+
+        # --- Direction-2 with full context reset ---
+        set_sp_context(
+            harness_name="fuzz_png",
+            sanitizer="address",
+            direction_id="dir_icc",
+            agent_id="spg_dir2",
+        )
+        create_suspicious_point_impl(
+            function_name="parse_icc",
+            vuln_type="out-of-bounds-read",
+            description="test",
+        )
+        kw_fixed = client.create_suspicious_point.call_args[1]
+        assert kw_fixed["direction_id"] == "dir_icc"
+
+    def test_parallel_verify_and_pov_update_isolated(self):
+        """
+        Verifier and POV agent run concurrently, both call update_sp_impl.
+        Verifier updates SP-1 with agent_id="verify_1".
+        POV agent updates SP-2 with agent_id="pov_1".
+
+        Cross-contamination = wrong agent_id in verified_by field.
+        """
+        captured = {}
+
+        async def _run():
+            event_1 = asyncio.Event()
+            event_2 = asyncio.Event()
+
+            async def verifier(my_event, other_event):
+                set_sp_context(
+                    harness_name="fuzz_png",
+                    sanitizer="address",
+                    direction_id="dir_chunk",
+                    agent_id="verify_1",
+                )
+                my_event.set()
+                await other_event.wait()
+
+                mock_client = _mock_client()
+                with patch(
+                    "fuzzingbrain.tools.suspicious_points._get_client",
+                    return_value=mock_client,
+                ), patch(
+                    "fuzzingbrain.tools.suspicious_points._ensure_client",
+                    return_value=None,
+                ):
+                    update_suspicious_point_impl(
+                        suspicious_point_id="sp_001",
+                        is_checked=True,
+                        is_real=True,
+                        is_important=True,
+                        verification_notes="Confirmed buffer overflow",
+                        pov_guidance="Oversize chunk length",
+                    )
+                    captured["verifier"] = (
+                        mock_client.update_suspicious_point.call_args[1]
+                    )
+
+            async def pov_agent(my_event, other_event):
+                set_sp_context(
+                    harness_name="fuzz_png",
+                    sanitizer="address",
+                    direction_id="dir_icc",
+                    agent_id="pov_1",
+                )
+                my_event.set()
+                await other_event.wait()
+
+                mock_client = _mock_client()
+                with patch(
+                    "fuzzingbrain.tools.suspicious_points._get_client",
+                    return_value=mock_client,
+                ), patch(
+                    "fuzzingbrain.tools.suspicious_points._ensure_client",
+                    return_value=None,
+                ):
+                    update_suspicious_point_impl(
+                        suspicious_point_id="sp_002",
+                        is_checked=True,
+                        is_real=True,
+                        is_important=True,
+                        verification_notes="Also confirmed",
+                        pov_guidance="Crafted ICC profile",
+                    )
+                    captured["pov"] = (
+                        mock_client.update_suspicious_point.call_args[1]
+                    )
+
+            await asyncio.gather(
+                verifier(event_1, event_2),
+                pov_agent(event_2, event_1),
+            )
+
+        asyncio.run(_run())
+
+        assert captured["verifier"]["agent_id"] == "verify_1"
+        assert captured["verifier"]["sp_id"] == "sp_001"
+        assert captured["pov"]["agent_id"] == "pov_1"
+        assert captured["pov"]["sp_id"] == "sp_002"

--- a/FuzzingBrain-v2/v2/tests/test_analyzer_socket_isolation.py
+++ b/FuzzingBrain-v2/v2/tests/test_analyzer_socket_isolation.py
@@ -1,0 +1,476 @@
+"""
+AnalysisClient Socket Isolation Tests
+
+Architecture:
+- Each TASK starts its own Analysis Server (Unix socket per task workspace)
+- Each WORKER connects to its task's analyzer socket via AnalysisClient
+- Within a worker, multiple AGENTS share the same client via _client_cache
+  keyed by (socket_path, client_id)
+- Agents issue parallel tool calls via asyncio.to_thread(), all hitting
+  the same AnalysisClient (same socket connection)
+
+Risks tested:
+- Parallel tool calls from one agent race on socket recv() without Lock
+- Task A's analyzer crash must not affect Task B's analyzer
+- Analyzer server restart mid-task must not leak stale data
+
+The mock server adds artificial delay to amplify race windows,
+making concurrency bugs deterministic instead of flaky.
+"""
+
+import json
+import os
+import socket
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pytest
+
+from fuzzingbrain.analyzer.client import AnalysisClient
+from fuzzingbrain.analyzer.protocol import (
+    Request,
+    Response,
+    encode_message,
+    decode_message,
+    MESSAGE_DELIMITER,
+)
+
+
+class MockAnalysisServer:
+    """
+    In-process Unix socket server that echoes back the request method
+    in the response data. Adds configurable delay to amplify race windows.
+
+    Each connection is handled in its own thread (mirrors real server behavior).
+    """
+
+    def __init__(self, socket_path: str, delay: float = 0.0):
+        self.socket_path = socket_path
+        self.delay = delay
+        self._server_sock = None
+        self._running = False
+        self._thread = None
+        self._connections = []
+        # Track requests received (for assertions)
+        self.requests_received: list = []
+        self._req_lock = threading.Lock()
+
+    def start(self):
+        self._server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server_sock.bind(self.socket_path)
+        self._server_sock.listen(10)
+        self._server_sock.settimeout(5.0)
+        self._running = True
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._running = False
+        for conn in self._connections:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        if self._server_sock:
+            self._server_sock.close()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    def _accept_loop(self):
+        while self._running:
+            try:
+                conn, _ = self._server_sock.accept()
+                self._connections.append(conn)
+                t = threading.Thread(
+                    target=self._handle_connection, args=(conn,), daemon=True
+                )
+                t.start()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+    def _handle_connection(self, conn: socket.socket):
+        """Handle a single client connection — read requests, send responses."""
+        conn.settimeout(5.0)
+        buf = b""
+        while self._running:
+            try:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+
+                # Process all complete messages in buffer
+                while MESSAGE_DELIMITER in buf:
+                    msg_end = buf.index(MESSAGE_DELIMITER)
+                    raw_msg = buf[:msg_end].decode("utf-8")
+                    buf = buf[msg_end + len(MESSAGE_DELIMITER):]
+
+                    request = Request.from_json(raw_msg)
+
+                    with self._req_lock:
+                        self.requests_received.append(request)
+
+                    # Delay to widen race window for concurrent tests
+                    if self.delay > 0:
+                        time.sleep(self.delay)
+
+                    # Echo back method + params as response data
+                    # so the caller can verify they got THEIR response
+                    response = Response.ok(
+                        data={
+                            "method": request.method,
+                            "request_id": request.request_id,
+                            "params": request.params,
+                        },
+                        request_id=request.request_id,
+                    )
+                    conn.sendall(encode_message(response.to_json()))
+
+            except socket.timeout:
+                continue
+            except (OSError, ConnectionError):
+                break
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def socket_path(tmp_path):
+    """Provide a temporary Unix socket path."""
+    return str(tmp_path / "test_analyzer.sock")
+
+
+@pytest.fixture
+def mock_server(socket_path):
+    """Start a mock analysis server, yield it, stop on cleanup."""
+    server = MockAnalysisServer(socket_path, delay=0.0)
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture
+def slow_server(socket_path):
+    """Mock server with 50ms delay per request — amplifies race conditions."""
+    server = MockAnalysisServer(socket_path, delay=0.05)
+    server.start()
+    yield server
+    server.stop()
+
+
+class TestParallelToolCalls:
+    """
+    The real scenario: an LLM returns 3 tool calls at once.
+    The agent framework dispatches them via asyncio.to_thread(),
+    all hitting the same AnalysisClient concurrently.
+
+    Without the Lock: thread A's recv() steals thread B's response.
+    With the Lock: requests are serialized, each thread gets its own response.
+    """
+
+    def test_concurrent_requests_get_correct_responses(self, socket_path, slow_server):
+        """
+        5 threads hit the same client simultaneously.
+        Each sends a different method — must get back their own method in response.
+
+        This is the exact bug we fixed: get_function_source() returning a dict
+        meant for create_suspicious_point(), or vice versa.
+        """
+        client = AnalysisClient(socket_path, timeout=10.0)
+        methods = [
+            "get_function_source",
+            "create_suspicious_point",
+            "get_callers",
+            "get_callees",
+            "get_reachability",
+        ]
+        results = {}
+        errors = []
+
+        def call_method(method: str):
+            try:
+                resp = client._request(method, {"name": f"test_{method}"})
+                return method, resp
+            except Exception as e:
+                return method, e
+
+        with ThreadPoolExecutor(max_workers=5) as pool:
+            futures = {pool.submit(call_method, m): m for m in methods}
+            for future in as_completed(futures):
+                method, resp = future.result()
+                if isinstance(resp, Exception):
+                    errors.append((method, resp))
+                else:
+                    results[method] = resp
+
+        assert not errors, f"Requests failed: {errors}"
+        assert len(results) == 5, f"Expected 5 results, got {len(results)}"
+
+        # The critical check: each thread got its OWN response
+        for method, resp in results.items():
+            assert resp["method"] == method, (
+                f"Response swap detected! Sent '{method}' but got response "
+                f"for '{resp['method']}' — this is the race condition bug"
+            )
+
+        client.close()
+
+    def test_parallel_calls_all_reach_server(self, socket_path, slow_server):
+        """
+        All parallel requests must actually reach the server.
+        The Lock serializes them, but none should be dropped.
+        """
+        client = AnalysisClient(socket_path, timeout=10.0)
+        n_calls = 8
+
+        def call(i):
+            return client._request("get_function", {"name": f"func_{i}"})
+
+        with ThreadPoolExecutor(max_workers=n_calls) as pool:
+            futures = [pool.submit(call, i) for i in range(n_calls)]
+            results = [f.result() for f in futures]
+
+        assert len(results) == n_calls
+        # Server must have received all 8
+        assert len(slow_server.requests_received) == n_calls, (
+            f"Server received {len(slow_server.requests_received)}/{n_calls} "
+            f"requests — some were dropped by Lock contention"
+        )
+
+        client.close()
+
+
+class TestTaskAnalyzerIsolation:
+    """
+    Each task has its own Analysis Server on a separate Unix socket.
+    Task A's analyzer crashing must NOT affect Task B's analyzer.
+
+    Real scenario: Task A's target binary triggers an OOM in the analyzer
+    server → Task A's socket dies. Task B on a different target has its
+    own analyzer server and must keep working.
+    """
+
+    def test_two_tasks_independent_analyzer_connections(self, tmp_path):
+        """
+        Task A and Task B each have their own analyzer server.
+        Task A's worker disconnects → Task B's worker still works.
+        """
+        sock_path = str(tmp_path / "shared_analyzer.sock")
+        server = MockAnalysisServer(sock_path)
+        server.start()
+
+        try:
+            client_a = AnalysisClient(sock_path, timeout=5.0, client_id="task_a_worker")
+            client_b = AnalysisClient(sock_path, timeout=5.0, client_id="task_b_worker")
+
+            # Both work initially
+            resp_a = client_a._request("get_function", {"name": "func_a"})
+            resp_b = client_b._request("get_function", {"name": "func_b"})
+            assert resp_a["params"]["name"] == "func_a"
+            assert resp_b["params"]["name"] == "func_b"
+
+            # Task A's worker disconnects (simulating crash/cleanup)
+            client_a.close()
+
+            # Task B's worker must still work — independent connection
+            resp_b2 = client_b._request("get_callees", {"function": "main"})
+            assert resp_b2["method"] == "get_callees"
+            assert resp_b2["params"]["function"] == "main"
+
+            client_b.close()
+        finally:
+            server.stop()
+
+    def test_task_analyzer_crash_does_not_propagate(self, tmp_path):
+        """
+        Task A's analyzer server crashes (socket dies).
+        Task B's analyzer server on a different socket is unaffected.
+        """
+        sock_a = str(tmp_path / "task_a_analyzer.sock")
+        sock_b = str(tmp_path / "task_b_analyzer.sock")
+
+        server_a = MockAnalysisServer(sock_a)
+        server_b = MockAnalysisServer(sock_b)
+        server_a.start()
+        server_b.start()
+
+        try:
+            client_a = AnalysisClient(sock_a, timeout=2.0)
+            client_b = AnalysisClient(sock_b, timeout=2.0)
+
+            # Both work
+            assert client_a._request("ping")["method"] == "ping"
+            assert client_b._request("ping")["method"] == "ping"
+
+            # Task A's analyzer crashes — its client's next request fails
+            server_a.stop()
+
+            with pytest.raises((ConnectionError, OSError, RuntimeError)):
+                client_a._request("get_function", {"name": "dead"})
+
+            # Task B's analyzer is unaffected (different server, different socket)
+            resp = client_b._request("get_function", {"name": "alive"})
+            assert resp["params"]["name"] == "alive"
+
+            client_a.close()
+            client_b.close()
+        finally:
+            server_b.stop()
+
+
+class TestSocketReconnection:
+    """
+    After a socket error, AnalysisClient._connect() creates a new socket.
+    Test that the new connection doesn't carry leftover data from the old one.
+
+    Real scenario: analyzer server restarts mid-task (e.g., OOM kill).
+    The client reconnects and must not get stale responses.
+    """
+
+    def test_reconnect_after_server_restart(self, tmp_path):
+        """
+        Client connects → server dies → server restarts → client reconnects.
+
+        Real behavior: the first request after server death fails (the client
+        detects the dead socket via recv error and calls _disconnect).
+        The NEXT request reconnects to the new server and succeeds.
+        This is the correct pattern — no stale data leaks across restarts.
+        """
+        sock_path = str(tmp_path / "restart_analyzer.sock")
+
+        # Phase 1: start server, make a request
+        server1 = MockAnalysisServer(sock_path)
+        server1.start()
+
+        client = AnalysisClient(sock_path, timeout=5.0)
+        resp1 = client._request("get_function", {"name": "before_restart"})
+        assert resp1["params"]["name"] == "before_restart"
+
+        # Phase 2: kill server (client's socket is now dead)
+        server1.stop()
+        os.unlink(sock_path)
+
+        # Phase 3: restart server on same path
+        server2 = MockAnalysisServer(sock_path)
+        server2.start()
+
+        try:
+            # First request fails — detects dead socket, triggers _disconnect()
+            with pytest.raises((ConnectionError, ConnectionResetError, OSError)):
+                client._request("get_function", {"name": "should_fail"})
+
+            # After the failure, client._sock is None (cleaned up).
+            # Next request reconnects to server2 with a fresh socket.
+            resp2 = client._request("get_function", {"name": "after_restart"})
+            assert resp2["params"]["name"] == "after_restart"
+
+            # Server 2 must have received this request (no leftover from server 1)
+            params_received = [
+                r.params.get("name") for r in server2.requests_received
+            ]
+            assert "after_restart" in params_received
+
+            client.close()
+        finally:
+            server2.stop()
+
+    def test_no_partial_response_after_reconnect(self, tmp_path):
+        """
+        If the old socket had buffered partial data, reconnection must
+        start clean. Verify by making multiple requests after reconnect.
+        """
+        sock_path = str(tmp_path / "partial_analyzer.sock")
+
+        server1 = MockAnalysisServer(sock_path)
+        server1.start()
+
+        client = AnalysisClient(sock_path, timeout=5.0)
+        client._request("ping")
+
+        # Force disconnect (simulate network glitch)
+        client._disconnect()
+
+        # Server is still running — client reconnects on next request
+        resp = client._request("get_callers", {"function": "target"})
+        assert resp["method"] == "get_callers"
+
+        # Second request after reconnect also works (no leftover buffer)
+        resp2 = client._request("get_callees", {"function": "target"})
+        assert resp2["method"] == "get_callees"
+
+        client.close()
+        server1.stop()
+
+
+class TestLockGranularity:
+    """
+    The Lock must cover the ENTIRE _request() method:
+    connect + send + recv as one atomic operation.
+
+    If only send or recv is locked, there's a window where:
+    - Thread A connects, sends, starts waiting for recv
+    - Thread B connects ON THE SAME SOCKET (no-op), sends its request
+    - Now two requests are in flight on one socket
+    - recv() returns the wrong one
+
+    We test that the lock prevents any interleaving.
+    """
+
+    def test_requests_are_strictly_serialized(self, socket_path, slow_server):
+        """
+        With 50ms server delay, 4 concurrent requests should take ~200ms
+        (serialized by Lock), not ~50ms (parallel).
+
+        This proves the Lock actually serializes — if it didn't, we'd see
+        ~50ms and response swapping.
+        """
+        client = AnalysisClient(socket_path, timeout=10.0)
+
+        results = []
+        errors = []
+
+        def timed_call(method):
+            start = time.monotonic()
+            try:
+                resp = client._request(method, {"name": "test"})
+                elapsed = time.monotonic() - start
+                return method, resp, elapsed
+            except Exception as e:
+                return method, e, 0
+
+        methods = ["get_function", "get_callers", "get_callees", "ping"]
+
+        start_all = time.monotonic()
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(timed_call, m) for m in methods]
+            for f in as_completed(futures):
+                method, resp, elapsed = f.result()
+                if isinstance(resp, Exception):
+                    errors.append((method, resp))
+                else:
+                    results.append((method, resp, elapsed))
+
+        total_time = time.monotonic() - start_all
+
+        assert not errors, f"Requests failed: {errors}"
+        assert len(results) == 4
+
+        # Serialized: total >= 4 * 50ms = 200ms
+        # If Lock was broken (parallel): total ≈ 50ms
+        assert total_time >= 0.15, (
+            f"Requests completed in {total_time:.3f}s — too fast! "
+            f"Lock is not serializing (expected >= 0.2s for 4 * 50ms delay)"
+        )
+
+        # Every response matches its request
+        for method, resp, _ in results:
+            assert resp["method"] == method
+
+        client.close()

--- a/FuzzingBrain-v2/v2/tests/test_direction_creation.py
+++ b/FuzzingBrain-v2/v2/tests/test_direction_creation.py
@@ -1,0 +1,417 @@
+"""
+Direction Creation Workflow Tests
+
+Tests the direction creation flow: LLM tool call → create_direction_impl → DB → find_pending.
+
+Business invariants under test:
+1. LLM params (name, risk_level, core_functions) flow correctly to analyzer client
+2. fuzzer is system-injected from ContextVar, not from LLM
+3. Invalid risk_level is rejected before reaching the server
+4. Created directions have PENDING status so find_pending() can retrieve them
+5. find_pending filters by task_id + fuzzer (cross-task/cross-fuzzer isolation)
+6. Direction planning failure → empty list → pipeline doesn't crash
+"""
+
+import asyncio
+from unittest.mock import patch, MagicMock
+
+import mongomock
+import pytest
+from bson import ObjectId
+
+from fuzzingbrain.core.models.direction import Direction, DirectionStatus
+from fuzzingbrain.db.repository import DirectionRepository
+from fuzzingbrain.tools.directions import (
+    create_direction_impl,
+    set_direction_context,
+    get_direction_context,
+)
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _mock_client_create_success(direction_id=None):
+    """Return a mock AnalysisClient whose create_direction returns success."""
+    client = MagicMock()
+    did = direction_id or str(ObjectId())
+    client.create_direction.return_value = {
+        "id": did,
+        "created": True,
+        "name": "test",
+        "risk_level": "high",
+    }
+    return client
+
+
+def _make_direction(task_id, fuzzer, name="test_dir", risk_level="high"):
+    """Create a Direction with given fields."""
+    return Direction(
+        task_id=task_id,
+        fuzzer=fuzzer,
+        name=name,
+        risk_level=risk_level,
+        risk_reason="buffer overflow in parser",
+        core_functions=["parse_chunk", "read_header"],
+        entry_functions=["LLVMFuzzerTestOneInput"],
+    )
+
+
+@pytest.fixture
+def direction_repo():
+    """Create a DirectionRepository backed by mongomock."""
+    client = mongomock.MongoClient()
+    db = client["test_fuzzingbrain"]
+    return DirectionRepository(db)
+
+
+# =========================================================================
+# Tests: Tool → Client field flow
+# =========================================================================
+
+
+class TestCreateDirectionFieldFlow:
+    """
+    Business rule: LLM parameters must arrive at the analyzer client unchanged.
+    System fields (fuzzer) must come from ContextVar, not from LLM.
+    """
+
+    @patch("fuzzingbrain.tools.directions._get_client")
+    @patch("fuzzingbrain.tools.directions._ensure_client", return_value=None)
+    def test_llm_params_forwarded_to_client(self, _ensure, mock_get_client):
+        """All LLM-provided params must reach client.create_direction."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+        set_direction_context("fuzz_png")
+
+        result = create_direction_impl(
+            name="Chunk Parsing",
+            risk_level="high",
+            risk_reason="Direct memory write from untrusted input",
+            core_functions=["parse_chunk", "decompress_data"],
+            entry_functions=["LLVMFuzzerTestOneInput"],
+            code_summary="Parses PNG chunk data",
+        )
+
+        assert result["success"] is True
+
+        call_kwargs = client.create_direction.call_args[1]
+        assert call_kwargs["name"] == "Chunk Parsing"
+        assert call_kwargs["risk_level"] == "high"
+        assert call_kwargs["risk_reason"] == "Direct memory write from untrusted input"
+        assert call_kwargs["core_functions"] == ["parse_chunk", "decompress_data"]
+        assert call_kwargs["entry_functions"] == ["LLVMFuzzerTestOneInput"]
+        assert call_kwargs["code_summary"] == "Parses PNG chunk data"
+
+    @patch("fuzzingbrain.tools.directions._get_client")
+    @patch("fuzzingbrain.tools.directions._ensure_client", return_value=None)
+    def test_fuzzer_injected_from_contextvar(self, _ensure, mock_get_client):
+        """fuzzer must come from ContextVar, not from LLM parameters."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        # System sets context — LLM never touches this
+        set_direction_context("fuzz_png")
+
+        create_direction_impl(
+            name="test",
+            risk_level="medium",
+            risk_reason="test",
+            core_functions=["foo"],
+        )
+
+        call_kwargs = client.create_direction.call_args[1]
+        assert call_kwargs["fuzzer"] == "fuzz_png"
+
+    @patch("fuzzingbrain.tools.directions._get_client")
+    @patch("fuzzingbrain.tools.directions._ensure_client", return_value=None)
+    def test_different_contextvar_different_fuzzer(self, _ensure, mock_get_client):
+        """Changing ContextVar must change the fuzzer in the next call."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        set_direction_context("fuzz_png")
+        create_direction_impl(
+            name="dir1", risk_level="high", risk_reason="r", core_functions=["a"]
+        )
+        first_fuzzer = client.create_direction.call_args[1]["fuzzer"]
+
+        set_direction_context("fuzz_icc")
+        create_direction_impl(
+            name="dir2", risk_level="high", risk_reason="r", core_functions=["b"]
+        )
+        second_fuzzer = client.create_direction.call_args[1]["fuzzer"]
+
+        assert first_fuzzer == "fuzz_png"
+        assert second_fuzzer == "fuzz_icc"
+
+    @patch("fuzzingbrain.tools.directions._get_client")
+    @patch("fuzzingbrain.tools.directions._ensure_client", return_value=None)
+    def test_risk_level_normalized_to_lowercase(self, _ensure, mock_get_client):
+        """LLM might send 'HIGH' or 'High' — must be lowercased before sending."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+        set_direction_context("fuzz_png")
+
+        create_direction_impl(
+            name="test", risk_level="HIGH", risk_reason="r", core_functions=["f"]
+        )
+
+        assert client.create_direction.call_args[1]["risk_level"] == "high"
+
+
+# =========================================================================
+# Tests: risk_level validation
+# =========================================================================
+
+
+class TestRiskLevelValidation:
+    """
+    Business rule: only high/medium/low are valid risk levels.
+    Invalid values must be rejected before reaching the server.
+    """
+
+    @patch("fuzzingbrain.tools.directions._get_client")
+    @patch("fuzzingbrain.tools.directions._ensure_client", return_value=None)
+    def test_invalid_risk_level_rejected(self, _ensure, mock_get_client):
+        """'critical' is not a valid risk level — must return error."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        result = create_direction_impl(
+            name="test",
+            risk_level="critical",
+            risk_reason="test",
+            core_functions=["foo"],
+        )
+
+        assert result["success"] is False
+        assert "Invalid risk_level" in result["error"]
+        client.create_direction.assert_not_called()
+
+    @patch("fuzzingbrain.tools.directions._get_client")
+    @patch("fuzzingbrain.tools.directions._ensure_client", return_value=None)
+    def test_all_valid_risk_levels_accepted(self, _ensure, mock_get_client):
+        """high, medium, low must all pass validation."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+        set_direction_context("fuzz_png")
+
+        for level in ["high", "medium", "low"]:
+            result = create_direction_impl(
+                name=f"test_{level}",
+                risk_level=level,
+                risk_reason="r",
+                core_functions=["f"],
+            )
+            assert result["success"] is True, f"risk_level '{level}' should be valid"
+
+
+# =========================================================================
+# Tests: Direction initial status + find_pending handoff
+# =========================================================================
+
+
+class TestDirectionPendingHandoff:
+    """
+    Business rule: a newly created Direction must have status=PENDING.
+    find_pending(task_id, fuzzer) must return it.
+    If status is wrong, find_pending won't find it and it's dead.
+    """
+
+    def test_new_direction_has_pending_status(self):
+        """Direction() defaults to PENDING — if this ever changes, pipeline breaks."""
+        d = Direction()
+        assert d.status == "pending"
+
+    def test_save_and_find_pending_returns_direction(self, direction_repo):
+        """Save a direction → find_pending must return it."""
+        task_id = str(ObjectId())
+        d = _make_direction(task_id, "fuzz_png", name="Chunk Parsing")
+        direction_repo.save(d)
+
+        found = direction_repo.find_pending(task_id, "fuzz_png")
+        assert len(found) == 1
+        assert found[0].name == "Chunk Parsing"
+        assert found[0].status == "pending"
+
+    def test_find_pending_excludes_completed(self, direction_repo):
+        """Completed directions must NOT appear in find_pending."""
+        task_id = str(ObjectId())
+
+        pending = _make_direction(task_id, "fuzz_png", name="pending_dir")
+        completed = _make_direction(task_id, "fuzz_png", name="completed_dir")
+        completed.status = DirectionStatus.COMPLETED.value
+
+        direction_repo.save(pending)
+        direction_repo.save(completed)
+
+        found = direction_repo.find_pending(task_id, "fuzz_png")
+        assert len(found) == 1
+        assert found[0].name == "pending_dir"
+
+    def test_find_pending_isolates_by_fuzzer(self, direction_repo):
+        """find_pending(fuzzer='fuzz_png') must not return fuzz_icc's directions."""
+        task_id = str(ObjectId())
+
+        d_png = _make_direction(task_id, "fuzz_png", name="png_dir")
+        d_icc = _make_direction(task_id, "fuzz_icc", name="icc_dir")
+
+        direction_repo.save(d_png)
+        direction_repo.save(d_icc)
+
+        found_png = direction_repo.find_pending(task_id, "fuzz_png")
+        found_icc = direction_repo.find_pending(task_id, "fuzz_icc")
+
+        assert len(found_png) == 1
+        assert found_png[0].name == "png_dir"
+        assert len(found_icc) == 1
+        assert found_icc[0].name == "icc_dir"
+
+    def test_find_pending_isolates_by_task(self, direction_repo):
+        """Directions from task A must not appear when querying task B."""
+        task_a = str(ObjectId())
+        task_b = str(ObjectId())
+
+        d_a = _make_direction(task_a, "fuzz_png", name="task_a_dir")
+        d_b = _make_direction(task_b, "fuzz_png", name="task_b_dir")
+
+        direction_repo.save(d_a)
+        direction_repo.save(d_b)
+
+        found_a = direction_repo.find_pending(task_a, "fuzz_png")
+        found_b = direction_repo.find_pending(task_b, "fuzz_png")
+
+        assert len(found_a) == 1
+        assert found_a[0].name == "task_a_dir"
+        assert len(found_b) == 1
+        assert found_b[0].name == "task_b_dir"
+
+    def test_multiple_directions_all_returned(self, direction_repo):
+        """3 pending directions → find_pending returns all 3."""
+        task_id = str(ObjectId())
+        for i in range(3):
+            d = _make_direction(task_id, "fuzz_png", name=f"dir_{i}")
+            direction_repo.save(d)
+
+        found = direction_repo.find_pending(task_id, "fuzz_png")
+        assert len(found) == 3
+
+
+# =========================================================================
+# Tests: Direction planning failure handling
+# =========================================================================
+
+
+class TestPlanningFailureHandling:
+    """
+    Business rule: if DirectionPlanningAgent fails (LLM timeout, tool error),
+    the strategy must return empty directions, not crash the worker.
+    """
+
+    def test_planning_exception_returns_empty_list(self):
+        """_run_direction_planning catches exception and returns []."""
+        from fuzzingbrain.worker.strategies.pov_fullscan import POVFullscanStrategy
+
+        # Create a minimal mock executor
+        executor = MagicMock()
+        executor.task_id = str(ObjectId())
+        executor.worker_id = str(ObjectId())
+        executor.fuzzer = "fuzz_png"
+        executor.sanitizer = "address"
+        executor.scan_mode = "full"
+        executor.workspace_path = "/tmp/test"
+        executor.results_path = MagicMock()
+        executor.project_name = "libpng"
+        executor.analysis_socket_path = None
+        executor.celery_job_id = "test"
+        executor.repos = MagicMock()
+        executor.fuzzer_binary_path = None
+
+        strategy = POVFullscanStrategy(executor)
+
+        # Mock DirectionPlanningAgent to raise
+        with patch(
+            "fuzzingbrain.worker.strategies.pov_fullscan.DirectionPlanningAgent"
+        ) as MockAgent:
+            MockAgent.return_value.plan_directions_sync.side_effect = RuntimeError(
+                "LLM API timeout"
+            )
+
+            result = strategy._run_direction_planning()
+
+        assert result == []
+
+    def test_no_directions_returns_empty_pipeline_stats(self):
+        """_run_full_pipeline with 0 directions → PipelineStats() not crash."""
+        from fuzzingbrain.worker.strategies.pov_fullscan import POVFullscanStrategy
+
+        executor = MagicMock()
+        executor.task_id = str(ObjectId())
+        executor.worker_id = str(ObjectId())
+        executor.fuzzer = "fuzz_png"
+        executor.sanitizer = "address"
+        executor.scan_mode = "full"
+        executor.workspace_path = "/tmp/test"
+        executor.results_path = MagicMock()
+        executor.project_name = "libpng"
+        executor.analysis_socket_path = None
+        executor.celery_job_id = "test"
+        executor.repos = MagicMock()
+        executor.fuzzer_binary_path = None
+
+        strategy = POVFullscanStrategy(executor)
+
+        # Mock planning to return empty
+        with patch.object(
+            strategy, "_run_direction_planning_async", return_value=[]
+        ):
+            stats = asyncio.run(strategy._run_full_pipeline())
+
+        # Should return empty stats, not crash
+        assert stats.sp_verified == 0
+        assert stats.pov_generated == 0
+
+
+# =========================================================================
+# Tests: Seed generation priority (risk_level sorting)
+# =========================================================================
+
+
+class TestSeedPriority:
+    """
+    Business rule: directions are sorted high → medium → low for seed generation.
+    Only top 5 directions get seed agents. If sorting is wrong,
+    low-value directions steal seed slots from high-value ones.
+    """
+
+    def test_high_risk_sorted_first(self):
+        """Sorted order must be: high → medium → low."""
+        directions = [
+            _make_direction(str(ObjectId()), "f", name="low_dir", risk_level="low"),
+            _make_direction(str(ObjectId()), "f", name="high_dir", risk_level="high"),
+            _make_direction(str(ObjectId()), "f", name="med_dir", risk_level="medium"),
+        ]
+
+        # This is the exact sort from pov_fullscan.py line 700-703
+        sorted_dirs = sorted(
+            directions,
+            key=lambda d: {"high": 0, "medium": 1, "low": 2}.get(d.risk_level, 3),
+        )
+
+        assert sorted_dirs[0].name == "high_dir"
+        assert sorted_dirs[1].name == "med_dir"
+        assert sorted_dirs[2].name == "low_dir"
+
+    def test_only_top_5_get_seeds(self):
+        """Strategy slices [:5] — 7 directions → only 5 get seed agents."""
+        directions = [
+            _make_direction(str(ObjectId()), "f", name=f"dir_{i}")
+            for i in range(7)
+        ]
+
+        # This is the exact slice from pov_fullscan.py line 741
+        selected = directions[:5]
+        assert len(selected) == 5

--- a/FuzzingBrain-v2/v2/tests/test_dispatch_workflow.py
+++ b/FuzzingBrain-v2/v2/tests/test_dispatch_workflow.py
@@ -1,0 +1,517 @@
+"""
+Dispatch Workflow Tests
+
+Tests the Task → Worker dispatch flow.
+
+Business invariants under test:
+1. N successful fuzzers × M sanitizers = exactly N×M workers dispatched
+2. Only fuzzers with status=SUCCESS are dispatched (FAILED/PENDING/BUILDING are skipped)
+3. fuzzer_filter restricts dispatch to named fuzzers only
+4. Each worker's assignment carries correct task_id, fuzzer, sanitizer, scan_mode
+5. Each worker gets an isolated (distinct) workspace
+6. One dispatch failure does not block the rest
+"""
+
+import pytest
+from pathlib import Path
+from typing import List
+from unittest.mock import patch, MagicMock
+
+from bson import ObjectId
+
+from fuzzingbrain.core.models.task import Task, JobType, ScanMode, TaskStatus
+from fuzzingbrain.core.models.fuzzer import Fuzzer, FuzzerStatus
+from fuzzingbrain.core.config import Config
+from fuzzingbrain.core.dispatcher import WorkerDispatcher
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _make_fuzzer(name: str, status: FuzzerStatus = FuzzerStatus.SUCCESS) -> Fuzzer:
+    """Create a Fuzzer with given name and status."""
+    return Fuzzer(
+        fuzzer_id=str(ObjectId()),
+        task_id=str(ObjectId()),
+        fuzzer_name=name,
+        status=status,
+    )
+
+
+def _make_task(task_id: str = None, tmp_path: Path = None) -> Task:
+    """Create a Task for testing."""
+    tid = task_id or str(ObjectId())
+    task_path = str(tmp_path) if tmp_path else "/tmp/test_task"
+    return Task(
+        task_id=tid,
+        task_type=JobType.POV,
+        scan_mode=ScanMode.FULL,
+        status=TaskStatus.RUNNING,
+        task_path=task_path,
+        project_name="libpng",
+    )
+
+
+def _make_config(
+    sanitizers: List[str] = None,
+    fuzzer_filter: List[str] = None,
+    timeout_minutes: int = 30,
+) -> Config:
+    """Create a Config for testing."""
+    return Config(
+        sanitizers=sanitizers or ["address"],
+        fuzzer_filter=fuzzer_filter or [],
+        ossfuzz_project_name="libpng",
+        timeout_minutes=timeout_minutes,
+        budget_limit=50.0,
+        pov_count=1,
+    )
+
+
+def _make_dispatcher(
+    task: Task,
+    config: Config,
+    repos: MagicMock = None,
+) -> WorkerDispatcher:
+    """Create a WorkerDispatcher with mocked dependencies."""
+    repos = repos or MagicMock()
+    dispatcher = WorkerDispatcher(
+        task=task,
+        config=config,
+        repos=repos,
+        analyze_result=None,
+    )
+    # Disable crash monitor (needs real infrastructure)
+    dispatcher.crash_monitor = None
+    return dispatcher
+
+
+# =========================================================================
+# Tests: Pair Generation (cartesian product invariant)
+# =========================================================================
+
+
+class TestPairGeneration:
+    """
+    Business rule: each fuzzer must be tested with each sanitizer.
+    The dispatch count is always |fuzzers| × |sanitizers|.
+    """
+
+    def test_single_fuzzer_single_sanitizer(self, tmp_path):
+        """1 × 1 = 1"""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config(sanitizers=["address"])
+        )
+        pairs = dispatcher._generate_pairs([_make_fuzzer("fuzz_png")], ["address"])
+
+        assert len(pairs) == 1
+        assert pairs[0] == {"fuzzer": "fuzz_png", "sanitizer": "address"}
+
+    def test_cartesian_product(self, tmp_path):
+        """2 fuzzers × 3 sanitizers = 6 unique pairs, no duplicates."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        fuzzers = [_make_fuzzer("fuzz_a"), _make_fuzzer("fuzz_b")]
+        sanitizers = ["address", "memory", "undefined"]
+        pairs = dispatcher._generate_pairs(fuzzers, sanitizers)
+
+        assert len(pairs) == 6
+
+        # Every combination must exist exactly once
+        pair_tuples = [(p["fuzzer"], p["sanitizer"]) for p in pairs]
+        assert len(set(pair_tuples)) == 6, "Duplicate pairs generated"
+        for f in ["fuzz_a", "fuzz_b"]:
+            for s in sanitizers:
+                assert (f, s) in pair_tuples, f"Missing pair ({f}, {s})"
+
+    def test_zero_fuzzers_zero_workers(self, tmp_path):
+        """No fuzzers = no pairs (not an error)."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        assert dispatcher._generate_pairs([], ["address"]) == []
+
+
+# =========================================================================
+# Tests: Status Filtering (only SUCCESS fuzzers get dispatched)
+# =========================================================================
+
+
+class TestStatusFiltering:
+    """
+    Business rule: only fuzzers that built successfully can be dispatched.
+    FAILED, PENDING, BUILDING fuzzers must never produce workers.
+    """
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_only_success_status_dispatched(
+        self, mock_workspace, mock_celery, tmp_path
+    ):
+        """4 fuzzers with different statuses → only the SUCCESS one is dispatched."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        mock_workspace.return_value = str(tmp_path / "ws")
+        mock_celery.return_value = {"celery_id": "c1", "fuzzer": "", "sanitizer": ""}
+
+        fuzzers = [
+            _make_fuzzer("good", FuzzerStatus.SUCCESS),
+            _make_fuzzer("bad", FuzzerStatus.FAILED),
+            _make_fuzzer("waiting", FuzzerStatus.PENDING),
+            _make_fuzzer("building", FuzzerStatus.BUILDING),
+        ]
+        jobs = dispatcher.dispatch(fuzzers)
+
+        assert len(jobs) == 1
+        dispatched_fuzzer = mock_celery.call_args[0][0]["fuzzer"]
+        assert dispatched_fuzzer == "good"
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_all_failed_produces_zero_workers(
+        self, mock_workspace, mock_celery, tmp_path
+    ):
+        """If every fuzzer failed to build, zero workers are dispatched."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        fuzzers = [
+            _make_fuzzer("a", FuzzerStatus.FAILED),
+            _make_fuzzer("b", FuzzerStatus.FAILED),
+        ]
+        jobs = dispatcher.dispatch(fuzzers)
+
+        assert jobs == []
+        mock_celery.assert_not_called()
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_empty_fuzzer_list_produces_zero_workers(
+        self, mock_workspace, mock_celery, tmp_path
+    ):
+        """Empty input → zero workers, no crash."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        assert dispatcher.dispatch([]) == []
+        mock_celery.assert_not_called()
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_multiple_success_all_dispatched(
+        self, mock_workspace, mock_celery, tmp_path
+    ):
+        """3 successful fuzzers × 1 sanitizer = exactly 3 workers."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config(sanitizers=["address"])
+        )
+        mock_workspace.return_value = str(tmp_path / "ws")
+        mock_celery.return_value = {"celery_id": "c", "fuzzer": "", "sanitizer": ""}
+
+        fuzzers = [_make_fuzzer(f"fuzz_{i}") for i in range(3)]
+        jobs = dispatcher.dispatch(fuzzers)
+
+        assert len(jobs) == 3
+        dispatched = {call[0][0]["fuzzer"] for call in mock_celery.call_args_list}
+        assert dispatched == {"fuzz_0", "fuzz_1", "fuzz_2"}
+
+
+# =========================================================================
+# Tests: Fuzzer Filter
+# =========================================================================
+
+
+class TestFuzzerFilter:
+    """
+    Business rule: when fuzzer_filter is set, only named fuzzers are dispatched
+    even if other fuzzers built successfully. Filter + status are AND conditions.
+    """
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_filter_selects_subset(self, mock_workspace, mock_celery, tmp_path):
+        """3 successful fuzzers, filter=["fuzz_png"] → only fuzz_png dispatched."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path),
+            _make_config(fuzzer_filter=["fuzz_png"]),
+        )
+        mock_workspace.return_value = str(tmp_path / "ws")
+        mock_celery.return_value = {"celery_id": "c", "fuzzer": "", "sanitizer": ""}
+
+        fuzzers = [
+            _make_fuzzer("fuzz_png"),
+            _make_fuzzer("fuzz_icc"),
+            _make_fuzzer("fuzz_text"),
+        ]
+        jobs = dispatcher.dispatch(fuzzers)
+
+        assert len(jobs) == 1
+        assert mock_celery.call_args[0][0]["fuzzer"] == "fuzz_png"
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_filter_no_match_zero_workers(self, mock_workspace, mock_celery, tmp_path):
+        """Filter names a fuzzer that doesn't exist → zero workers."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path),
+            _make_config(fuzzer_filter=["nonexistent"]),
+        )
+        fuzzers = [_make_fuzzer("fuzz_png"), _make_fuzzer("fuzz_icc")]
+        assert dispatcher.dispatch(fuzzers) == []
+        mock_celery.assert_not_called()
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_filter_and_status_are_and_conditions(
+        self, mock_workspace, mock_celery, tmp_path
+    ):
+        """Filter matches fuzz_icc but it FAILED → zero workers for fuzz_icc."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path),
+            _make_config(fuzzer_filter=["fuzz_png", "fuzz_icc"]),
+        )
+        mock_workspace.return_value = str(tmp_path / "ws")
+        mock_celery.return_value = {"celery_id": "c", "fuzzer": "", "sanitizer": ""}
+
+        fuzzers = [
+            _make_fuzzer("fuzz_png", FuzzerStatus.SUCCESS),
+            _make_fuzzer("fuzz_icc", FuzzerStatus.FAILED),
+            _make_fuzzer("fuzz_text", FuzzerStatus.SUCCESS),  # not in filter
+        ]
+        jobs = dispatcher.dispatch(fuzzers)
+
+        assert len(jobs) == 1
+        assert mock_celery.call_args[0][0]["fuzzer"] == "fuzz_png"
+
+
+# =========================================================================
+# Tests: Assignment Content (what actually reaches Celery)
+# =========================================================================
+
+
+class TestCeleryAssignment:
+    """
+    Business rule: the assignment dict sent to Celery must contain all fields
+    that run_worker needs to function correctly. Missing fields cause runtime
+    failures inside the Celery worker.
+
+    These tests let _dispatch_celery_task run for real (only mock apply_async)
+    to verify the actual assignment dict.
+    """
+
+    @patch("fuzzingbrain.core.logging.get_log_dir", return_value=None)
+    @patch("fuzzingbrain.worker.tasks.run_worker.apply_async")
+    def test_assignment_has_required_fields(
+        self, mock_apply, mock_log_dir, tmp_path
+    ):
+        """Assignment must contain every field that run_worker() destructures."""
+        task_id = str(ObjectId())
+        task = _make_task(task_id=task_id, tmp_path=tmp_path)
+        config = _make_config()
+        dispatcher = _make_dispatcher(task, config)
+
+        mock_result = MagicMock()
+        mock_result.id = "celery-job-123"
+        mock_apply.return_value = mock_result
+
+        # Create workspace for real
+        pair = {"fuzzer": "fuzz_png", "sanitizer": "address"}
+        ws = dispatcher._create_worker_workspace(pair)
+
+        dispatcher._dispatch_celery_task(pair, ws)
+
+        # Extract the assignment dict sent to Celery
+        assignment = mock_apply.call_args[1]["args"][0] if "args" in mock_apply.call_args[1] else mock_apply.call_args[0][0][0]
+
+        # Required fields that run_worker() reads with [] (KeyError if missing)
+        required_keys = ["task_id", "fuzzer", "sanitizer", "task_type",
+                         "workspace_path", "project_name"]
+        for key in required_keys:
+            assert key in assignment, f"Assignment missing required field: {key}"
+
+        # Verify values are correct (not just present)
+        assert assignment["task_id"] == task_id
+        assert assignment["fuzzer"] == "fuzz_png"
+        assert assignment["sanitizer"] == "address"
+        assert assignment["task_type"] == "pov"
+        assert assignment["workspace_path"] == ws
+        assert assignment["scan_mode"] == "full"
+
+    @patch("fuzzingbrain.core.logging.get_log_dir", return_value=None)
+    @patch("fuzzingbrain.worker.tasks.run_worker.apply_async")
+    def test_each_pair_gets_correct_assignment(
+        self, mock_apply, mock_log_dir, tmp_path
+    ):
+        """2 fuzzers × 2 sanitizers: each Celery call gets its own fuzzer+sanitizer."""
+        task = _make_task(tmp_path=tmp_path)
+        config = _make_config(sanitizers=["address", "memory"])
+        dispatcher = _make_dispatcher(task, config)
+
+        mock_result = MagicMock()
+        mock_result.id = "celery-job"
+        mock_apply.return_value = mock_result
+
+        fuzzers = [_make_fuzzer("fuzz_a"), _make_fuzzer("fuzz_b")]
+        dispatcher.dispatch(fuzzers)
+
+        assert mock_apply.call_count == 4
+
+        # Extract all (fuzzer, sanitizer) pairs from actual Celery calls
+        celery_pairs = set()
+        for call in mock_apply.call_args_list:
+            args = call[1].get("args") or call[0][0]
+            assignment = args[0]
+            celery_pairs.add((assignment["fuzzer"], assignment["sanitizer"]))
+
+        assert celery_pairs == {
+            ("fuzz_a", "address"), ("fuzz_a", "memory"),
+            ("fuzz_b", "address"), ("fuzz_b", "memory"),
+        }
+
+    @patch("fuzzingbrain.core.logging.get_log_dir", return_value=None)
+    @patch("fuzzingbrain.worker.tasks.run_worker.apply_async")
+    def test_celery_timeout_derived_from_config(
+        self, mock_apply, mock_log_dir, tmp_path
+    ):
+        """Celery time_limit must match config.timeout_minutes × 60."""
+        task = _make_task(tmp_path=tmp_path)
+        config = _make_config(timeout_minutes=45)
+        dispatcher = _make_dispatcher(task, config)
+
+        mock_result = MagicMock()
+        mock_result.id = "celery-job"
+        mock_apply.return_value = mock_result
+
+        pair = {"fuzzer": "fuzz_png", "sanitizer": "address"}
+        ws = dispatcher._create_worker_workspace(pair)
+        dispatcher._dispatch_celery_task(pair, ws)
+
+        call_kwargs = mock_apply.call_args[1]
+        assert call_kwargs["time_limit"] == 45 * 60
+        assert call_kwargs["soft_time_limit"] == int(45 * 60 * 0.9)
+
+
+# =========================================================================
+# Tests: Workspace Isolation
+# =========================================================================
+
+
+class TestWorkspaceIsolation:
+    """
+    Business rule: each worker must get its own isolated workspace.
+    Sharing a workspace would cause file conflicts between workers.
+    """
+
+    def test_different_pairs_get_different_workspaces(self, tmp_path):
+        """Two distinct pairs must produce two distinct workspace paths."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        ws_a = dispatcher._create_worker_workspace(
+            {"fuzzer": "fuzz_png", "sanitizer": "address"}
+        )
+        ws_b = dispatcher._create_worker_workspace(
+            {"fuzzer": "fuzz_png", "sanitizer": "memory"}
+        )
+        assert ws_a != ws_b, "Different pairs must get different workspaces"
+        assert Path(ws_a).exists()
+        assert Path(ws_b).exists()
+
+    def test_workspace_is_clean_on_redispatch(self, tmp_path):
+        """Re-dispatching same pair gives a clean workspace (no leftover files)."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        pair = {"fuzzer": "fuzz_png", "sanitizer": "address"}
+
+        ws = dispatcher._create_worker_workspace(pair)
+        (Path(ws) / "stale_crash.txt").write_text("old data")
+
+        ws2 = dispatcher._create_worker_workspace(pair)
+        assert not (Path(ws2) / "stale_crash.txt").exists(), \
+            "Stale files from previous run must be removed"
+
+    def test_workspace_has_results_dir(self, tmp_path):
+        """Every workspace must have a results/ directory for outputs."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        ws = dispatcher._create_worker_workspace(
+            {"fuzzer": "fuzz_png", "sanitizer": "address"}
+        )
+        assert (Path(ws) / "results").is_dir()
+
+
+# =========================================================================
+# Tests: Fault Tolerance
+# =========================================================================
+
+
+class TestFaultTolerance:
+    """
+    Business rule: dispatch is best-effort per pair.
+    One pair failing must not prevent other pairs from being dispatched.
+    """
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_one_failure_does_not_block_others(
+        self, mock_workspace, mock_celery, tmp_path
+    ):
+        """3 fuzzers, first one fails to dispatch → 2 still succeed."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+        mock_workspace.return_value = str(tmp_path / "ws")
+
+        call_count = [0]
+
+        def side_effect(pair, workspace_path):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("Celery connection lost")
+            return {
+                "celery_id": "c",
+                "fuzzer": pair["fuzzer"],
+                "sanitizer": pair["sanitizer"],
+            }
+
+        mock_celery.side_effect = side_effect
+
+        fuzzers = [_make_fuzzer("a"), _make_fuzzer("b"), _make_fuzzer("c")]
+        jobs = dispatcher.dispatch(fuzzers)
+
+        assert mock_celery.call_count == 3, "All 3 must be attempted"
+        assert len(jobs) == 2, "2 of 3 should succeed"
+
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._dispatch_celery_task")
+    @patch("fuzzingbrain.core.dispatcher.WorkerDispatcher._create_worker_workspace")
+    def test_workspace_failure_does_not_block_others(
+        self, mock_workspace, mock_celery, tmp_path
+    ):
+        """If workspace creation fails for one pair, others still proceed."""
+        dispatcher = _make_dispatcher(
+            _make_task(tmp_path=tmp_path), _make_config()
+        )
+
+        call_count = [0]
+
+        def ws_side_effect(pair):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise OSError("Disk full")
+            return str(tmp_path / "ws")
+
+        mock_workspace.side_effect = ws_side_effect
+        mock_celery.return_value = {"celery_id": "c", "fuzzer": "", "sanitizer": ""}
+
+        fuzzers = [_make_fuzzer("a"), _make_fuzzer("b")]
+        jobs = dispatcher.dispatch(fuzzers)
+
+        # First workspace fails, so first celery call is skipped.
+        # Second workspace succeeds, second celery call succeeds.
+        assert len(jobs) == 1

--- a/FuzzingBrain-v2/v2/tests/test_pipeline_chain.py
+++ b/FuzzingBrain-v2/v2/tests/test_pipeline_chain.py
@@ -1,0 +1,786 @@
+"""
+Pipeline Chain Integration Tests — Bug-Hunting Probes
+
+Each test asserts the CORRECT invariant (what the code SHOULD do).
+Tests marked @pytest.mark.xfail are known bugs — they FAIL today,
+proving the bug exists. When the bug is fixed, they will PASS and
+pytest will report them as XPASS (unexpectedly passing), signaling
+the xfail marker should be removed.
+
+Known bugs:
+  1. __exit__ pops registry BEFORE DB save → zombie worker/agent on save failure
+  2. increment_*() counters are read-modify-write without lock → lost updates
+  3. claim_for_verify() has no recovery → orphaned SPs stuck forever
+  5. update_status() allows backward transitions (completed → running)
+  6. __enter__() has no reentrance guard → started_at overwritten
+"""
+
+import threading
+import time
+from datetime import datetime
+from unittest.mock import patch
+
+import mongomock
+import pytest
+from bson import ObjectId
+
+from fuzzingbrain.worker.context import (
+    WorkerContext,
+    _worker_contexts,
+    _worker_contexts_lock,
+    get_workers_by_task,
+)
+from fuzzingbrain.agents.context import (
+    AgentContext,
+    _agent_contexts,
+    _agent_contexts_lock,
+)
+from fuzzingbrain.core.models import SPStatus
+from fuzzingbrain.core.models.direction import DirectionStatus
+from fuzzingbrain.db.repository import SuspiciousPointRepository, DirectionRepository
+
+
+# All local imports in context.py use `from ..db import get_database`
+# and `from ..llms.buffer import ...`, so we patch at the source module.
+DB_PATCH = "fuzzingbrain.db.get_database"
+LLM_BUFFER_PATCH = "fuzzingbrain.llms.buffer.WorkerLLMBuffer"
+SET_BUFFER_PATCH = "fuzzingbrain.llms.buffer.set_worker_buffer"
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def clean_registries():
+    """Clear global in-memory registries before and after every test."""
+    with _worker_contexts_lock:
+        _worker_contexts.clear()
+    with _agent_contexts_lock:
+        _agent_contexts.clear()
+    yield
+    with _worker_contexts_lock:
+        _worker_contexts.clear()
+    with _agent_contexts_lock:
+        _agent_contexts.clear()
+
+
+@pytest.fixture
+def mock_db():
+    """Fresh mongomock database per test."""
+    client = mongomock.MongoClient()
+    db = client["fuzzingbrain_test"]
+    yield db
+    client.close()
+
+
+@pytest.fixture
+def patch_worker_db(mock_db):
+    """Route WorkerContext._save_to_db through mongomock."""
+    with patch(DB_PATCH, return_value=mock_db):
+        with patch(LLM_BUFFER_PATCH):
+            with patch(SET_BUFFER_PATCH):
+                yield mock_db
+
+
+@pytest.fixture
+def patch_agent_db(mock_db):
+    """Route AgentContext._save_to_db through mongomock."""
+    with patch(DB_PATCH, return_value=mock_db):
+        yield mock_db
+
+
+@pytest.fixture
+def task_id():
+    """A stable task ObjectId string."""
+    return str(ObjectId())
+
+
+@pytest.fixture
+def sp_repo(mock_db):
+    """SuspiciousPointRepository backed by mongomock."""
+    return SuspiciousPointRepository(mock_db)
+
+
+@pytest.fixture
+def dir_repo(mock_db):
+    """DirectionRepository backed by mongomock."""
+    return DirectionRepository(mock_db)
+
+
+def _make_worker(task_id: str, **kwargs) -> WorkerContext:
+    """Helper to build a WorkerContext with sensible defaults."""
+    return WorkerContext(
+        task_id=task_id,
+        fuzzer=kwargs.get("fuzzer", "libfuzzer"),
+        sanitizer=kwargs.get("sanitizer", "address"),
+        project_name=kwargs.get("project_name", "test-project"),
+    )
+
+
+def _make_agent(task_id: str, worker_id: str, **kwargs) -> AgentContext:
+    """Helper to build an AgentContext with sensible defaults."""
+    return AgentContext(
+        task_id=task_id,
+        worker_id=worker_id,
+        agent_type=kwargs.get("agent_type", "POVAgent"),
+        fuzzer=kwargs.get("fuzzer", "libfuzzer"),
+        sanitizer=kwargs.get("sanitizer", "address"),
+    )
+
+
+# =============================================================================
+# Class 1: Ghost Worker/Agent on __exit__ save failure  (Bug 1 — SEVERE)
+#
+# Root cause: __exit__ used to pop from registry BEFORE saving to DB.
+# If save failed, the worker was gone from both memory and DB (zombie).
+# Fix: save first, only pop from registry if save succeeds. If save fails,
+# the worker stays in memory so get_workers_by_task() returns correct status.
+# =============================================================================
+
+
+class TestWorkerGhostOnSaveFailure:
+    """
+    Invariant: After __exit__, the worker's final status (completed/failed)
+    must be queryable — via DB if save succeeded, via in-memory if it didn't.
+    """
+
+    def test_worker_stays_in_registry_when_exit_save_fails(self, task_id, mock_db):
+        """
+        If __exit__'s DB save fails, the worker must stay in the
+        in-memory registry so it remains queryable.
+        """
+        call_count = 0
+
+        def controlled_get_db():
+            nonlocal call_count
+            call_count += 1
+            # __enter__: 2 calls (LLM buffer + initial save) → succeed
+            # __exit__: 3rd call → fail
+            if call_count <= 2:
+                return mock_db
+            raise ConnectionError("DB down on exit")
+
+        with patch(DB_PATCH, side_effect=controlled_get_db):
+            with patch(LLM_BUFFER_PATCH):
+                with patch(SET_BUFFER_PATCH):
+                    ctx = _make_worker(task_id)
+                    ctx.__enter__()
+                    worker_id = ctx.worker_id
+                    ctx.__exit__(None, None, None)
+
+        # Worker must still be in memory registry (save failed → not popped)
+        assert worker_id in _worker_contexts, (
+            "Worker must stay in registry when final save fails"
+        )
+        # In-memory status must be the final status
+        assert _worker_contexts[worker_id].status == "completed"
+
+    def test_worker_query_returns_final_status_on_save_failure(self, task_id, mock_db):
+        """
+        get_workers_by_task must return the correct final status
+        even when DB save failed — via in-memory merge.
+        """
+        call_count = 0
+
+        def controlled_get_db():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return mock_db
+            raise ConnectionError("DB down on exit")
+
+        with patch(DB_PATCH, side_effect=controlled_get_db):
+            with patch(LLM_BUFFER_PATCH):
+                with patch(SET_BUFFER_PATCH):
+                    ctx = _make_worker(task_id)
+                    ctx.__enter__()
+                    ctx.__exit__(None, None, None)
+
+        # Query uses in-memory merge to override stale DB record
+        with patch(DB_PATCH, return_value=mock_db):
+            workers = get_workers_by_task(task_id)
+
+        assert len(workers) == 1
+        assert workers[0]["status"] in ("completed", "failed")
+
+    def test_worker_exit_retries_save_on_transient_failure(self, task_id, mock_db):
+        """
+        If __exit__'s first DB save fails but the retry succeeds,
+        the worker must be properly saved to DB and removed from registry.
+        """
+        call_count = 0
+
+        def controlled_get_db():
+            nonlocal call_count
+            call_count += 1
+            # __enter__: calls 1-2 succeed (buffer + initial save)
+            # __exit__: call 3 fails (first attempt), call 4 succeeds (retry)
+            if call_count == 3:
+                raise ConnectionError("transient DB failure")
+            return mock_db
+
+        with patch(DB_PATCH, side_effect=controlled_get_db):
+            with patch(LLM_BUFFER_PATCH):
+                with patch(SET_BUFFER_PATCH):
+                    ctx = _make_worker(task_id)
+                    ctx.__enter__()
+                    worker_id = ctx.worker_id
+                    ctx.__exit__(None, None, None)
+
+        # Retry succeeded → removed from registry
+        assert worker_id not in _worker_contexts, \
+            "Worker should be removed after retry succeeds"
+        # DB has correct final status
+        doc = mock_db.workers.find_one({"_id": ObjectId(worker_id)})
+        assert doc is not None
+        assert doc["status"] == "completed"
+
+    def test_worker_removed_from_registry_when_save_succeeds(self, patch_worker_db, task_id):
+        """
+        Normal case: save succeeds → worker is removed from registry
+        and DB has the correct final status.
+        """
+        ctx = _make_worker(task_id)
+        ctx.__enter__()
+        worker_id = ctx.worker_id
+        ctx.__exit__(None, None, None)
+
+        # Removed from memory
+        assert worker_id not in _worker_contexts
+        # DB has correct status
+        doc = patch_worker_db.workers.find_one({"_id": ObjectId(worker_id)})
+        assert doc["status"] == "completed"
+
+    def test_agent_stays_in_registry_when_exit_save_fails(self, task_id, mock_db):
+        """Same fix for AgentContext: stays in memory if save fails."""
+        call_count = 0
+
+        def controlled_get_db():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                return mock_db
+            raise ConnectionError("DB down on exit")
+
+        worker_id = str(ObjectId())
+
+        with patch(DB_PATCH, side_effect=controlled_get_db):
+            ctx = _make_agent(task_id, worker_id)
+            ctx.__enter__()
+            agent_id = ctx.agent_id
+            ctx.__exit__(None, None, None)
+
+        # Agent must still be in memory registry
+        assert agent_id in _agent_contexts, (
+            "Agent must stay in registry when final save fails"
+        )
+        assert _agent_contexts[agent_id].status == "completed"
+
+
+# =============================================================================
+# Class 2: Counter Race Conditions  (Bug 2 — MEDIUM)
+#
+# Root cause: `self.agents_spawned += 1` is non-atomic read-modify-write.
+# _save_lock only protects _save_to_db, not the counter increment.
+# CPython GIL makes this hard to trigger, but the code is still wrong.
+# =============================================================================
+
+
+class TestCounterRaceConditions:
+    """
+    Invariant: N concurrent increments must produce counter == N.
+    """
+
+    def test_concurrent_increment_agents_spawned(self, patch_worker_db, task_id):
+        """50 threads each increment once → counter must be exactly 50."""
+        ctx = _make_worker(task_id)
+        ctx.__enter__()
+
+        n_threads = 50
+        barrier = threading.Barrier(n_threads)
+        errors = []
+
+        def inc():
+            try:
+                barrier.wait(timeout=5)
+                ctx.increment_agents_spawned()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=inc) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Thread errors: {errors}"
+        # CORRECT invariant: counter == N
+        # CPython GIL may mask the race, so xfail only if race is detected
+        assert ctx.agents_spawned == n_threads, (
+            f"Race condition: expected {n_threads}, got {ctx.agents_spawned} "
+            f"(lost {n_threads - ctx.agents_spawned} updates)"
+        )
+
+        ctx.__exit__(None, None, None)
+
+    def test_concurrent_increment_sp_found_with_force_save(self, patch_worker_db, task_id):
+        """
+        increment_sp_found calls _save_to_db(force=True) → heavier lock
+        contention makes the unprotected counter race more likely.
+        """
+        ctx = _make_worker(task_id)
+        ctx.__enter__()
+
+        n_threads = 20
+        barrier = threading.Barrier(n_threads)
+        errors = []
+
+        def inc():
+            try:
+                barrier.wait(timeout=5)
+                ctx.increment_sp_found(count=1)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=inc) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Thread errors: {errors}"
+        assert ctx.sp_found == n_threads, (
+            f"Race condition: expected {n_threads}, got {ctx.sp_found} "
+            f"(lost {n_threads - ctx.sp_found} updates)"
+        )
+
+        ctx.__exit__(None, None, None)
+
+
+# =============================================================================
+# Class 3: Orphaned SP Claims  (Bug 3 — SEVERE)
+#
+# Root cause: claim_for_verify() sets status to "verifying" atomically,
+# but there is no timeout, TTL, or reaper. If the agent crashes without
+# calling release_claim(), the SP is stuck forever.
+# =============================================================================
+
+
+class TestOrphanedClaims:
+    """
+    Invariant: An orphaned claim (agent crashed after claim) must be
+    recoverable by another agent without manual intervention.
+
+    Tests all three claim types: verify, POV, and direction.
+    """
+
+    # ---- helpers ----
+
+    def _insert_pending_verify_sp(self, mock_db, task_id: str) -> str:
+        """Insert a pending_verify SP, return its ID."""
+        sp_id = ObjectId()
+        mock_db.suspicious_points.insert_one({
+            "_id": sp_id,
+            "task_id": ObjectId(task_id),
+            "function_name": "vuln_func",
+            "status": SPStatus.PENDING_VERIFY.value,
+            "score": 0.8,
+            "is_important": False,
+            "is_checked": False,
+            "is_real": False,
+            "sources": [{"harness_name": "fuzz_x", "sanitizer": "address"}],
+            "created_at": datetime.now(),
+        })
+        return str(sp_id)
+
+    def _insert_pending_pov_sp(self, mock_db, task_id: str) -> str:
+        """Insert a pending_pov SP, return its ID."""
+        sp_id = ObjectId()
+        mock_db.suspicious_points.insert_one({
+            "_id": sp_id,
+            "task_id": ObjectId(task_id),
+            "function_name": "vuln_func",
+            "status": SPStatus.PENDING_POV.value,
+            "score": 0.9,
+            "is_important": True,
+            "is_checked": True,
+            "is_real": True,
+            "pov_success_by": None,
+            "pov_attempted_by": [],
+            "sources": [{"harness_name": "fuzz_x", "sanitizer": "address"}],
+            "created_at": datetime.now(),
+        })
+        return str(sp_id)
+
+    def _insert_pending_direction(self, mock_db, task_id: str, fuzzer: str = "fuzz_x") -> str:
+        """Insert a pending direction, return its ID."""
+        dir_id = ObjectId()
+        mock_db.directions.insert_one({
+            "_id": dir_id,
+            "task_id": ObjectId(task_id),
+            "fuzzer": fuzzer,
+            "name": "test_direction",
+            "description": "test",
+            "status": DirectionStatus.PENDING.value,
+            "risk_level": "high",
+            "core_functions": ["func_a"],
+            "entry_functions": ["main"],
+            "created_at": datetime.now(),
+        })
+        return str(dir_id)
+
+    # ---- Verify claim tests ----
+
+    def test_verify_crash_releases_claim_via_finally(self, mock_db, task_id, sp_repo):
+        """
+        Simulate pipeline's finally block: agent crashes after claiming,
+        finally calls release_claim, next agent can reclaim.
+
+        This is the fix for Bug #3a: pipeline.py's try/finally ensures
+        release_claim is always called, even on KeyboardInterrupt/CancelledError.
+        """
+        self._insert_pending_verify_sp(mock_db, task_id)
+
+        claimed1 = sp_repo.claim_for_verify(task_id, processor_id="agent-001")
+        assert claimed1 is not None
+        assert claimed1.status == "verifying"
+
+        # Agent 1 "crashes" — pipeline's finally block calls release_claim
+        released = sp_repo.release_claim(
+            claimed1.suspicious_point_id, revert_status="pending_verify"
+        )
+        assert released is True
+
+        # Agent 2 can now reclaim
+        claimed2 = sp_repo.claim_for_verify(task_id, processor_id="agent-002")
+        assert claimed2 is not None, (
+            "SP must be reclaimable after release_claim in finally block"
+        )
+
+    def test_verify_release_claim_restores_to_pending(self, mock_db, task_id, sp_repo):
+        """
+        Explicit release_claim correctly restores the SP.
+        Proves recovery path exists but requires manual intervention.
+        """
+        sp_id = self._insert_pending_verify_sp(mock_db, task_id)
+
+        claimed = sp_repo.claim_for_verify(task_id, processor_id="agent-001")
+        assert claimed is not None
+
+        released = sp_repo.release_claim(sp_id, revert_status="pending_verify")
+        assert released is True
+
+        claimed2 = sp_repo.claim_for_verify(task_id, processor_id="agent-002")
+        assert claimed2 is not None
+
+    # ---- POV claim tests ----
+
+    def test_pov_orphaned_sp_reclaimable_by_different_worker(self, mock_db, task_id, sp_repo):
+        """
+        POV claim allows re-claiming by a DIFFERENT fuzzer/sanitizer combo
+        because query matches both pending_pov and generating_pov.
+
+        Note: claim_for_pov without harness_name/sanitizer skips the
+        sources and pov_attempted_by filters, so any worker can reclaim.
+        """
+        self._insert_pending_pov_sp(mock_db, task_id)
+
+        # Worker A claims (with source filter)
+        claimed1 = sp_repo.claim_for_pov(
+            task_id, processor_id="agent-001",
+            harness_name="fuzz_x", sanitizer="address",
+        )
+        assert claimed1 is not None
+
+        # Worker A "crashes" — SP stays in generating_pov
+
+        # Worker B (no filter — simulates a different worker that can handle any SP)
+        claimed2 = sp_repo.claim_for_pov(
+            task_id, processor_id="agent-002",
+        )
+        assert claimed2 is not None, (
+            "Orphaned POV SP must be reclaimable by a different worker"
+        )
+
+    def test_pov_crash_releases_claim_and_attempted_by(self, mock_db, task_id, sp_repo):
+        """
+        Simulate pipeline's finally block for POV: agent crashes after claiming,
+        finally calls release_claim with harness_name/sanitizer to also clean
+        pov_attempted_by, so the same worker can retry.
+
+        This is the fix for Bug #3c: release_claim now accepts harness_name/sanitizer
+        to remove the pov_attempted_by entry on crash recovery.
+        """
+        self._insert_pending_pov_sp(mock_db, task_id)
+
+        # Worker A claims
+        claimed1 = sp_repo.claim_for_pov(
+            task_id, processor_id="agent-001",
+            harness_name="fuzz_x", sanitizer="address",
+        )
+        assert claimed1 is not None
+
+        # Worker A "crashes" — pipeline's finally block calls release_claim
+        # with harness_name/sanitizer to clean pov_attempted_by
+        released = sp_repo.release_claim(
+            claimed1.suspicious_point_id,
+            revert_status="pending_pov",
+            harness_name="fuzz_x",
+            sanitizer="address",
+        )
+        assert released is True
+
+        # Same worker combo can now retry
+        claimed2 = sp_repo.claim_for_pov(
+            task_id, processor_id="agent-001",
+            harness_name="fuzz_x", sanitizer="address",
+        )
+        assert claimed2 is not None, (
+            "Same worker should be able to retry after crash with pov_attempted_by cleanup"
+        )
+
+    # ---- Direction claim tests ----
+
+    def test_direction_crash_releases_claim(self, mock_db, task_id, dir_repo):
+        """
+        After an agent claims a direction and crashes, release_claim
+        restores it to pending so another agent can reclaim.
+
+        Note: directions.claim() is currently not called in production code
+        (fullscan uses find_pending() directly), but this tests the mechanism
+        in case it's wired up in the future.
+        """
+        dir_id = self._insert_pending_direction(mock_db, task_id)
+
+        claimed1 = dir_repo.claim(task_id, fuzzer="fuzz_x", processor_id="agent-001")
+        assert claimed1 is not None
+
+        # Agent "crashes" — release_claim restores to pending
+        released = dir_repo.release_claim(dir_id)
+        assert released is True
+
+        # Another agent can now reclaim
+        claimed2 = dir_repo.claim(task_id, fuzzer="fuzz_x", processor_id="agent-002")
+        assert claimed2 is not None, (
+            "Direction must be reclaimable after release_claim"
+        )
+
+    def test_direction_release_claim_restores_to_pending(self, mock_db, task_id, dir_repo):
+        """
+        Explicit release_claim correctly restores the direction.
+        Proves recovery path exists but requires manual invocation.
+        """
+        dir_id = self._insert_pending_direction(mock_db, task_id)
+
+        claimed = dir_repo.claim(task_id, fuzzer="fuzz_x", processor_id="agent-001")
+        assert claimed is not None
+
+        released = dir_repo.release_claim(dir_id)
+        assert released is True
+
+        claimed2 = dir_repo.claim(task_id, fuzzer="fuzz_x", processor_id="agent-002")
+        assert claimed2 is not None
+
+
+# =============================================================================
+# Class 4: ObjectId Chain Integrity
+# =============================================================================
+
+
+class TestObjectIdChainIntegrity:
+    """
+    Invariant: Task → Worker → Agent chain must be fully traceable via DB,
+    and query APIs must not produce duplicates regardless of argument type.
+    """
+
+    def test_full_chain_task_worker_agent_trace(self, patch_worker_db, patch_agent_db, task_id):
+        """
+        Create 1 Task → 2 Workers → 2 Agents each.
+        Verify the full chain is traceable through DB queries.
+        """
+        db = patch_agent_db
+
+        worker_ids = []
+
+        for i in range(2):
+            w_ctx = _make_worker(task_id, fuzzer=f"fuzzer_{i}")
+            w_ctx.__enter__()
+            worker_ids.append(w_ctx.worker_id)
+
+            for j in range(2):
+                a_ctx = _make_agent(task_id, w_ctx.worker_id, agent_type=f"Agent_{i}_{j}")
+                a_ctx.__enter__()
+                a_ctx.__exit__(None, None, None)
+
+            w_ctx.__exit__(None, None, None)
+
+        # Verify workers found by task_id
+        worker_docs = list(db.workers.find({"task_id": ObjectId(task_id)}))
+        assert len(worker_docs) == 2, f"Expected 2 workers, got {len(worker_docs)}"
+
+        # Verify agents found by worker_id
+        for wid in worker_ids:
+            agent_docs = list(db.agents.find({"worker_id": ObjectId(wid)}))
+            assert len(agent_docs) == 2, (
+                f"Expected 2 agents for worker {wid[:8]}, got {len(agent_docs)}"
+            )
+
+        # Verify total agents found by task_id
+        all_agents = list(db.agents.find({"task_id": ObjectId(task_id)}))
+        assert len(all_agents) == 4, f"Expected 4 agents total, got {len(all_agents)}"
+
+    def test_get_workers_by_task_no_duplicates_with_objectid_arg(self, patch_worker_db, task_id):
+        """
+        Passing ObjectId(task_id) to get_workers_by_task must not
+        produce duplicate entries for a running worker.
+        """
+        ctx = _make_worker(task_id)
+        ctx.__enter__()
+        worker_id = ctx.worker_id
+
+        workers = get_workers_by_task(ObjectId(task_id))
+        wids = [w["worker_id"] for w in workers]
+
+        ctx.__exit__(None, None, None)
+
+        assert wids.count(worker_id) == 1, (
+            f"Duplicate workers returned: {wids}"
+        )
+
+    def test_get_workers_by_task_no_duplicates_with_str_arg(self, patch_worker_db, task_id):
+        """Control: passing str(task_id) must also not produce duplicates."""
+        ctx = _make_worker(task_id)
+        ctx.__enter__()
+        worker_id = ctx.worker_id
+
+        workers = get_workers_by_task(str(task_id))
+        wids = [w["worker_id"] for w in workers]
+
+        ctx.__exit__(None, None, None)
+
+        assert wids.count(worker_id) == 1, (
+            f"Duplicate workers returned: {wids}"
+        )
+
+
+# =============================================================================
+# Class 5: Status Transition Guards  (Bug 5 — LOW)
+#
+# Root cause: update_status() does `self.status = status` with no validation.
+# =============================================================================
+
+
+class TestStatusTransitionGuards:
+    """
+    Invariant: Status transitions must be monotonic
+    (pending → running → completed|failed). Backward transitions
+    should be rejected.
+    """
+
+    def test_update_status_rejects_backward_transition(self, patch_worker_db, task_id):
+        """
+        Once a worker is 'completed', calling update_status('running')
+        should be rejected (status stays 'completed').
+        """
+        ctx = _make_worker(task_id)
+        ctx.__enter__()
+
+        ctx.status = "completed"
+        ctx.update_status("running")
+
+        # CORRECT invariant: backward transition rejected
+        assert ctx.status == "completed", (
+            "Status should remain 'completed' — backward transition not allowed"
+        )
+
+        ctx.__exit__(None, None, None)
+
+    def test_double_exit_preserves_first_status(self, patch_worker_db, task_id):
+        """
+        After a clean __exit__ (completed), a second __exit__ with error
+        should not flip the status to 'failed'.
+        """
+        ctx = _make_worker(task_id)
+        ctx.__enter__()
+
+        ctx.__exit__(None, None, None)
+        doc = patch_worker_db.workers.find_one({"_id": ObjectId(ctx.worker_id)})
+        assert doc["status"] == "completed"
+
+        # Second exit with error — should be ignored
+        ctx.__exit__(RuntimeError, RuntimeError("oops"), None)
+        doc = patch_worker_db.workers.find_one({"_id": ObjectId(ctx.worker_id)})
+
+        # CORRECT invariant: first exit wins
+        assert doc["status"] == "completed"
+
+
+# =============================================================================
+# Class 6: Context Reentrance  (Bug 6 — LOW)
+#
+# Root cause: __enter__() has no guard against being called twice.
+# =============================================================================
+
+
+class TestContextReentrance:
+    """
+    Invariant: __enter__ should be idempotent (return same context,
+    preserve started_at) or raise on re-entry.
+    """
+
+    def test_worker_double_enter_preserves_started_at(self, patch_worker_db, task_id):
+        """Second __enter__ should not overwrite started_at."""
+        ctx = _make_worker(task_id)
+
+        ctx.__enter__()
+        first_started = ctx.started_at
+
+        time.sleep(0.01)
+
+        ctx.__enter__()
+
+        # CORRECT invariant: started_at preserved
+        assert ctx.started_at == first_started, (
+            "started_at must not change on re-entry"
+        )
+
+        ctx.__exit__(None, None, None)
+
+    def test_agent_double_enter_preserves_started_at(self, patch_agent_db, task_id):
+        """Same invariant for AgentContext."""
+        worker_id = str(ObjectId())
+        ctx = _make_agent(task_id, worker_id)
+
+        ctx.__enter__()
+        first_started = ctx.started_at
+
+        time.sleep(0.01)
+
+        ctx.__enter__()
+
+        assert ctx.started_at == first_started, (
+            "started_at must not change on re-entry"
+        )
+
+        ctx.__exit__(None, None, None)
+
+    def test_exit_without_enter_does_not_crash(self, patch_worker_db, task_id):
+        """__exit__ without __enter__ should not raise."""
+        ctx = _make_worker(task_id)
+
+        try:
+            ctx.__exit__(None, None, None)
+        except Exception as e:
+            pytest.fail(f"__exit__ without __enter__ raised: {e}")
+
+    def test_agent_exit_without_enter_does_not_crash(self, patch_agent_db, task_id):
+        """Same for AgentContext."""
+        worker_id = str(ObjectId())
+        ctx = _make_agent(task_id, worker_id)
+
+        try:
+            ctx.__exit__(None, None, None)
+        except Exception as e:
+            pytest.fail(f"AgentContext.__exit__ without __enter__ raised: {e}")

--- a/FuzzingBrain-v2/v2/tests/test_repository.py
+++ b/FuzzingBrain-v2/v2/tests/test_repository.py
@@ -1,0 +1,1129 @@
+"""
+Repository CRUD tests with mongomock.
+
+Tests are organized by BUSINESS SCENARIOS, not by repository methods.
+Each test exercises a real production workflow or edge case that could
+break and cause actual damage.
+"""
+
+import pytest
+from bson import ObjectId
+
+from fuzzingbrain.core.models import (
+    Task,
+    TaskStatus,
+    POV,
+    Patch,
+    SuspiciousPoint,
+    SPStatus,
+    Direction,
+    DirectionStatus,
+    RiskLevel,
+    Worker,
+    WorkerStatus,
+    Fuzzer,
+    FuzzerStatus,
+    Function,
+    CallGraphNode,
+)
+from fuzzingbrain.core.utils import generate_id
+
+
+# =========================================================================
+# Task Lifecycle
+# =========================================================================
+
+
+class TestTaskLifecycle:
+    """Task goes pending → running → collects POVs/patches → completed."""
+
+    def test_task_accumulates_povs_and_patches(self, repos):
+        """As workers find POVs and patches, they accumulate on the task."""
+        task = Task(project_name="openssl")
+        repos.tasks.save(task)
+        repos.tasks.update_status(task.task_id, "running")
+
+        pov1, pov2, patch1 = generate_id(), generate_id(), generate_id()
+        repos.tasks.add_pov(task.task_id, pov1)
+        repos.tasks.add_pov(task.task_id, pov2)
+        repos.tasks.add_patch(task.task_id, patch1)
+
+        found = repos.tasks.find_by_id(task.task_id)
+        assert found.status == TaskStatus.RUNNING
+        assert len(found.pov_ids) == 2
+        assert len(found.patch_ids) == 1
+        assert pov1 in found.pov_ids
+        assert pov2 in found.pov_ids
+
+    def test_find_by_status_only_returns_matching(self, repos):
+        """Dispatcher queries pending tasks to launch them."""
+        pending = Task(project_name="proj1", status=TaskStatus.PENDING)
+        running = Task(project_name="proj2", status=TaskStatus.RUNNING)
+        done = Task(project_name="proj3", status=TaskStatus.COMPLETED)
+        for t in [pending, running, done]:
+            repos.tasks.save(t)
+
+        result = repos.tasks.find_by_status("pending")
+        assert len(result) == 1
+        assert result[0].project_name == "proj1"
+
+    def test_find_by_project_isolates_tasks(self, repos):
+        """Multiple tasks for different projects don't cross-contaminate."""
+        t1 = Task(project_name="openssl")
+        t2 = Task(project_name="curl")
+        for t in [t1, t2]:
+            repos.tasks.save(t)
+
+        found = repos.tasks.find_by_project("openssl")
+        assert len(found) == 1
+        assert found[0].task_id == t1.task_id
+
+    def test_save_is_idempotent_upsert(self, repos):
+        """Saving the same task twice doesn't create duplicates."""
+        task = Task(project_name="test")
+        repos.tasks.save(task)
+        task.project_name = "updated"
+        repos.tasks.save(task)
+
+        assert repos.tasks.count() == 1
+        found = repos.tasks.find_by_id(task.task_id)
+        assert found.project_name == "updated"
+
+    def test_delete_cleans_up_task(self, repos):
+        task = Task()
+        repos.tasks.save(task)
+        assert repos.tasks.delete(task.task_id)
+        assert repos.tasks.find_by_id(task.task_id) is None
+
+
+# =========================================================================
+# SP Pipeline: The Core Business Flow
+#
+# Real flow: pending_verify → [claim] → verifying → [complete_verify] →
+#   verified (false positive) OR pending_pov → [claim_for_pov] →
+#   generating_pov → [complete_pov] → pov_generated / failed
+# =========================================================================
+
+
+class TestSPPipelineLifecycle:
+    """End-to-end suspicious point pipeline tests."""
+
+    def _make_sp(self, task_id, **kwargs):
+        defaults = dict(
+            task_id=task_id,
+            function_name="vuln_func",
+            direction_id=generate_id(),
+            description="heap-buffer-overflow in vuln_func",
+            vuln_type="heap-buffer-overflow",
+            sources=[{"harness_name": "fuzz1", "sanitizer": "address"}],
+        )
+        defaults.update(kwargs)
+        return SuspiciousPoint(**defaults)
+
+    def test_full_pipeline_verify_to_pov_success(self, repos):
+        """SP flows through entire pipeline: create → verify → POV success."""
+        task_id = generate_id()
+        sp = self._make_sp(task_id, score=0.8)
+        repos.suspicious_points.save(sp)
+
+        # Step 1: Verifier agent claims
+        claimed = repos.suspicious_points.claim_for_verify(task_id, "verifier_1")
+        assert claimed.suspicious_point_id == sp.suspicious_point_id
+        assert claimed.status == SPStatus.VERIFYING.value
+
+        # Step 2: Verifier confirms real, sends to POV stage
+        repos.suspicious_points.complete_verify(
+            sp.suspicious_point_id, is_real=True, score=0.95,
+            notes="confirmed via manual analysis", proceed_to_pov=True,
+        )
+        found = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert found.status == SPStatus.PENDING_POV.value
+        assert found.is_checked is True
+        assert found.is_real is True
+        assert found.score == 0.95
+
+        # Step 3: POV worker claims
+        pov_claimed = repos.suspicious_points.claim_for_pov(
+            task_id, "pov_worker_1",
+            harness_name="fuzz1", sanitizer="address",
+        )
+        assert pov_claimed is not None
+        assert pov_claimed.status == SPStatus.GENERATING_POV.value
+
+        # Step 4: POV worker succeeds
+        pov_id = generate_id()
+        result = repos.suspicious_points.complete_pov(
+            sp.suspicious_point_id, pov_id=pov_id, success=True,
+            harness_name="fuzz1", sanitizer="address",
+        )
+        assert result is True
+
+        # Final state check
+        final = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert final.status == SPStatus.POV_GENERATED.value
+        assert final.pov_id == pov_id
+        assert final.pov_success_by["harness_name"] == "fuzz1"
+
+    def test_verify_false_positive_stays_terminal(self, repos):
+        """SP verified as false positive → VERIFIED (terminal), not in POV pipeline."""
+        task_id = generate_id()
+        sp = self._make_sp(task_id, score=0.4)
+        repos.suspicious_points.save(sp)
+
+        repos.suspicious_points.claim_for_verify(task_id, "verifier_1")
+        repos.suspicious_points.complete_verify(
+            sp.suspicious_point_id, is_real=False, score=0.1,
+            proceed_to_pov=False,
+        )
+
+        found = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert found.status == SPStatus.VERIFIED.value
+        assert found.is_real is False
+
+        # Pipeline should consider this SP done
+        assert repos.suspicious_points.is_pipeline_complete(task_id) is True
+
+    def test_all_workers_fail_pov_marks_failed(self, repos):
+        """When every source worker fails POV, SP transitions to FAILED."""
+        task_id = generate_id()
+        sp = self._make_sp(
+            task_id,
+            status=SPStatus.PENDING_POV.value,
+            score=0.8,
+            sources=[
+                {"harness_name": "fuzzA", "sanitizer": "address"},
+                {"harness_name": "fuzzB", "sanitizer": "address"},
+            ],
+        )
+        repos.suspicious_points.save(sp)
+
+        # Worker A claims and fails
+        repos.suspicious_points.claim_for_pov(
+            task_id, "wA", harness_name="fuzzA", sanitizer="address"
+        )
+        repos.suspicious_points.complete_pov(
+            sp.suspicious_point_id, success=False,
+            harness_name="fuzzA", sanitizer="address",
+        )
+
+        # SP should not be failed yet — worker B hasn't tried
+        mid = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert mid.status != SPStatus.FAILED.value
+
+        # Worker B claims and fails
+        repos.suspicious_points.claim_for_pov(
+            task_id, "wB", harness_name="fuzzB", sanitizer="address"
+        )
+        repos.suspicious_points.complete_pov(
+            sp.suspicious_point_id, success=False,
+            harness_name="fuzzB", sanitizer="address",
+        )
+
+        # Now ALL sources have tried and failed → FAILED
+        final = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert final.status == SPStatus.FAILED.value
+
+
+    def test_release_claim_on_verifier_crash(self, repos):
+        """If a verifier crashes, release_claim reverts SP so another agent can retry."""
+        task_id = generate_id()
+        sp = self._make_sp(task_id, score=0.7)
+        repos.suspicious_points.save(sp)
+
+        # Agent claims
+        claimed = repos.suspicious_points.claim_for_verify(task_id, "agent_1")
+        assert claimed.status == SPStatus.VERIFYING.value
+
+        # Agent crashes → release with revert
+        repos.suspicious_points.release_claim(
+            sp.suspicious_point_id, revert_status=SPStatus.PENDING_VERIFY.value
+        )
+
+        found = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert found.status == SPStatus.PENDING_VERIFY.value
+
+        # Another agent can now claim it
+        reclaimed = repos.suspicious_points.claim_for_verify(task_id, "agent_2")
+        assert reclaimed is not None
+        assert reclaimed.suspicious_point_id == sp.suspicious_point_id
+
+
+class TestSPClaimScheduling:
+    """SP claim priority and exclusion logic."""
+
+    def _make_sp(self, task_id, **kwargs):
+        defaults = dict(
+            task_id=task_id,
+            function_name="vuln_func",
+            direction_id=generate_id(),
+            description="overflow",
+            vuln_type="heap-buffer-overflow",
+            sources=[{"harness_name": "fuzz1", "sanitizer": "address"}],
+        )
+        defaults.update(kwargs)
+        return SuspiciousPoint(**defaults)
+
+    def test_claim_verify_respects_priority(self, repos):
+        """Important SPs claimed before high-score, high-score before low."""
+        task_id = generate_id()
+        low = self._make_sp(task_id, score=0.3, is_important=False)
+        high = self._make_sp(task_id, score=0.9, is_important=False)
+        important = self._make_sp(task_id, score=0.5, is_important=True)
+        for sp in [low, high, important]:
+            repos.suspicious_points.save(sp)
+
+        c1 = repos.suspicious_points.claim_for_verify(task_id, "a1")
+        assert c1.suspicious_point_id == important.suspicious_point_id
+
+        c2 = repos.suspicious_points.claim_for_verify(task_id, "a2")
+        assert c2.suspicious_point_id == high.suspicious_point_id
+
+        c3 = repos.suspicious_points.claim_for_verify(task_id, "a3")
+        assert c3.suspicious_point_id == low.suspicious_point_id
+
+        # Nothing left
+        assert repos.suspicious_points.claim_for_verify(task_id, "a4") is None
+
+    def test_claim_pov_excludes_already_attempted(self, repos):
+        """Worker that already attempted POV on this SP cannot claim it again."""
+        task_id = generate_id()
+        sp = self._make_sp(
+            task_id,
+            status=SPStatus.PENDING_POV.value,
+            score=0.8,
+            sources=[
+                {"harness_name": "fuzzA", "sanitizer": "address"},
+                {"harness_name": "fuzzB", "sanitizer": "address"},
+            ],
+        )
+        repos.suspicious_points.save(sp)
+
+        # Worker A claims
+        c1 = repos.suspicious_points.claim_for_pov(
+            task_id, "wA", harness_name="fuzzA", sanitizer="address"
+        )
+        assert c1 is not None
+
+        # Worker A tries again → excluded
+        c2 = repos.suspicious_points.claim_for_pov(
+            task_id, "wA", harness_name="fuzzA", sanitizer="address"
+        )
+        assert c2 is None
+
+        # Worker B can still claim the same SP
+        c3 = repos.suspicious_points.claim_for_pov(
+            task_id, "wB", harness_name="fuzzB", sanitizer="address"
+        )
+        assert c3 is not None
+
+    def test_pov_first_success_wins_race(self, repos):
+        """Two workers generate POV simultaneously — only first success recorded."""
+        task_id = generate_id()
+        sp = self._make_sp(
+            task_id,
+            status=SPStatus.GENERATING_POV.value,
+            score=0.8,
+            sources=[
+                {"harness_name": "fuzzA", "sanitizer": "address"},
+                {"harness_name": "fuzzB", "sanitizer": "address"},
+            ],
+        )
+        repos.suspicious_points.save(sp)
+
+        # Worker A succeeds
+        assert repos.suspicious_points.complete_pov(
+            sp.suspicious_point_id, pov_id=generate_id(), success=True,
+            harness_name="fuzzA", sanitizer="address",
+        ) is True
+
+        # Worker B also succeeds, but too late
+        assert repos.suspicious_points.complete_pov(
+            sp.suspicious_point_id, pov_id=generate_id(), success=True,
+            harness_name="fuzzB", sanitizer="address",
+        ) is False
+
+        final = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert final.pov_success_by["harness_name"] == "fuzzA"
+        assert final.status == SPStatus.POV_GENERATED.value
+
+    def test_claim_pov_respects_min_score(self, repos):
+        """SPs below min_score are not claimable for POV."""
+        task_id = generate_id()
+        low_score = self._make_sp(
+            task_id, status=SPStatus.PENDING_POV.value, score=0.3,
+        )
+        repos.suspicious_points.save(low_score)
+
+        # Default min_score=0.5, so score 0.3 should not be claimable
+        claimed = repos.suspicious_points.claim_for_pov(
+            task_id, "w1", harness_name="fuzz1", sanitizer="address",
+        )
+        assert claimed is None
+
+        # But with lower threshold, it should be claimable
+        claimed2 = repos.suspicious_points.claim_for_pov(
+            task_id, "w1", min_score=0.2,
+            harness_name="fuzz1", sanitizer="address",
+        )
+        assert claimed2 is not None
+
+
+class TestSPSourceMerging:
+    """When multiple fuzzers find the same SP, sources merge via $addToSet."""
+
+    def test_same_source_not_duplicated(self, repos):
+        """$addToSet prevents duplicate harness/sanitizer pairs."""
+        task_id = generate_id()
+        sp = SuspiciousPoint(
+            task_id=task_id, function_name="f",
+            direction_id=generate_id(),
+            description="d", vuln_type="v",
+            sources=[],
+        )
+        repos.suspicious_points.save(sp)
+
+        repos.suspicious_points.add_source(sp.suspicious_point_id, "fuzz1", "address")
+        repos.suspicious_points.add_source(sp.suspicious_point_id, "fuzz1", "address")
+        repos.suspicious_points.add_source(sp.suspicious_point_id, "fuzz2", "address")
+
+        found = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert len(found.sources) == 2  # fuzz1/addr + fuzz2/addr, not 3
+
+    def test_merged_duplicate_records_original_info(self, repos):
+        """When deduplicating SPs, the duplicate's metadata is preserved."""
+        task_id = generate_id()
+        primary = SuspiciousPoint(
+            task_id=task_id, function_name="f",
+            direction_id=generate_id(),
+            description="primary desc", vuln_type="heap-overflow",
+            sources=[{"harness_name": "fuzz1", "sanitizer": "address"}],
+        )
+        repos.suspicious_points.save(primary)
+
+        # Duplicate found by fuzz2 gets merged into primary
+        repos.suspicious_points.add_merged_duplicate(
+            primary.suspicious_point_id,
+            description="duplicate desc from fuzz2",
+            vuln_type="heap-buffer-overflow",
+            harness_name="fuzz2", sanitizer="address",
+            score=0.7,
+        )
+
+        found = repos.suspicious_points.find_by_id(primary.suspicious_point_id)
+        assert len(found.merged_duplicates) == 1
+        assert found.merged_duplicates[0]["description"] == "duplicate desc from fuzz2"
+        assert found.merged_duplicates[0]["harness_name"] == "fuzz2"
+
+
+class TestSPPipelineCompletion:
+    """Pipeline completion checks drive the worker termination decision."""
+
+    def _make_sp(self, task_id, **kwargs):
+        defaults = dict(
+            task_id=task_id, function_name="f",
+            direction_id=generate_id(),
+            description="d", vuln_type="v",
+            sources=[{"harness_name": "fuzz1", "sanitizer": "address"}],
+        )
+        defaults.update(kwargs)
+        return SuspiciousPoint(**defaults)
+
+    def test_terminal_states_mean_complete(self, repos):
+        """Pipeline is complete when all SPs are in terminal states."""
+        task_id = generate_id()
+        repos.suspicious_points.save(
+            self._make_sp(task_id, status=SPStatus.POV_GENERATED.value)
+        )
+        repos.suspicious_points.save(
+            self._make_sp(task_id, status=SPStatus.FAILED.value)
+        )
+        repos.suspicious_points.save(
+            self._make_sp(task_id, status=SPStatus.VERIFIED.value)
+        )
+        repos.suspicious_points.save(
+            self._make_sp(task_id, status=SPStatus.SKIPPED.value)
+        )
+        assert repos.suspicious_points.is_pipeline_complete(task_id) is True
+
+    def test_pending_sp_blocks_completion(self, repos):
+        """One pending_verify SP means pipeline is NOT complete."""
+        task_id = generate_id()
+        repos.suspicious_points.save(
+            self._make_sp(task_id, status=SPStatus.POV_GENERATED.value)
+        )
+        repos.suspicious_points.save(
+            self._make_sp(task_id, status=SPStatus.PENDING_VERIFY.value)
+        )
+        assert repos.suspicious_points.is_pipeline_complete(task_id) is False
+
+    def test_worker_specific_completion(self, repos):
+        """Worker checks completion for its own harness/sanitizer only."""
+        task_id = generate_id()
+        # SP that only fuzz1 cares about — still pending
+        sp_fuzz1 = self._make_sp(
+            task_id, status=SPStatus.PENDING_VERIFY.value,
+            sources=[{"harness_name": "fuzz1", "sanitizer": "address"}],
+        )
+        # SP that only fuzz2 cares about — done
+        sp_fuzz2 = self._make_sp(
+            task_id, status=SPStatus.POV_GENERATED.value,
+            sources=[{"harness_name": "fuzz2", "sanitizer": "address"}],
+        )
+        repos.suspicious_points.save(sp_fuzz1)
+        repos.suspicious_points.save(sp_fuzz2)
+
+        # fuzz2/address is done (its SPs are all terminal)
+        assert repos.suspicious_points.is_pipeline_complete(
+            task_id, harness_name="fuzz2", sanitizer="address"
+        ) is True
+
+        # fuzz1/address is NOT done (still has pending_verify)
+        assert repos.suspicious_points.is_pipeline_complete(
+            task_id, harness_name="fuzz1", sanitizer="address"
+        ) is False
+
+    def test_worker_specific_pov_stage_completion(self, repos):
+        """Worker's POV pipeline is complete once it has attempted all its SPs.
+
+        The POV-stage query checks: contributor + not succeeded + not attempted.
+        After a worker attempts a POV (even if it fails), that SP is "done"
+        for that worker.
+        """
+        task_id = generate_id()
+        sp = self._make_sp(
+            task_id,
+            status=SPStatus.PENDING_POV.value,
+            score=0.8,
+            sources=[
+                {"harness_name": "fuzzA", "sanitizer": "address"},
+                {"harness_name": "fuzzB", "sanitizer": "address"},
+            ],
+        )
+        repos.suspicious_points.save(sp)
+
+        # fuzzA has un-attempted SPs → NOT complete
+        assert repos.suspicious_points.is_pipeline_complete(
+            task_id, harness_name="fuzzA", sanitizer="address"
+        ) is False
+
+        # fuzzA claims and fails
+        repos.suspicious_points.claim_for_pov(
+            task_id, "wA", harness_name="fuzzA", sanitizer="address"
+        )
+        repos.suspicious_points.complete_pov(
+            sp.suspicious_point_id, success=False,
+            harness_name="fuzzA", sanitizer="address",
+        )
+
+        # fuzzA has now attempted its only SP → complete for fuzzA
+        assert repos.suspicious_points.is_pipeline_complete(
+            task_id, harness_name="fuzzA", sanitizer="address"
+        ) is True
+
+        # But fuzzB still hasn't attempted → NOT complete for fuzzB
+        assert repos.suspicious_points.is_pipeline_complete(
+            task_id, harness_name="fuzzB", sanitizer="address"
+        ) is False
+
+    def test_count_by_status_breakdown(self, repos):
+        """Status counts drive the dashboard and scheduling decisions."""
+        task_id = generate_id()
+        repos.suspicious_points.save(
+            self._make_sp(task_id, is_checked=True, is_real=True, is_important=True)
+        )
+        repos.suspicious_points.save(
+            self._make_sp(task_id, is_checked=True, is_real=False)
+        )
+        repos.suspicious_points.save(
+            self._make_sp(task_id, is_checked=False)
+        )
+
+        counts = repos.suspicious_points.count_by_status(task_id)
+        assert counts["total"] == 3
+        assert counts["checked"] == 2
+        assert counts["unchecked"] == 1
+        assert counts["real"] == 1
+        assert counts["false_positive"] == 1
+        assert counts["important"] == 1
+
+
+# =========================================================================
+# Direction → SP Find Workflow
+# =========================================================================
+
+
+class TestDirectionWorkflow:
+    """Directions represent analysis plans that agents claim and execute."""
+
+    def _make_dir(self, task_id, **kwargs):
+        defaults = dict(
+            task_id=task_id, fuzzer="fuzz_target",
+            name="check_null_deref_in_parser",
+            risk_level=RiskLevel.MEDIUM.value,
+        )
+        defaults.update(kwargs)
+        return Direction(**defaults)
+
+    def test_claim_respects_risk_priority(self, repos):
+        """High-risk directions are claimed before low-risk."""
+        task_id = generate_id()
+        low = self._make_dir(task_id, name="low_risk_dir", risk_level=RiskLevel.LOW.value)
+        high = self._make_dir(task_id, name="high_risk_dir", risk_level=RiskLevel.HIGH.value)
+        # Save low first to prove order doesn't matter
+        repos.directions.save(low)
+        repos.directions.save(high)
+
+        claimed = repos.directions.claim(task_id, "fuzz_target", "agent_1")
+        assert claimed.direction_id == high.direction_id
+        assert claimed.status == DirectionStatus.IN_PROGRESS.value
+
+    def test_complete_records_analysis_results(self, repos):
+        """After analyzing a direction, sp_count and functions_analyzed are recorded."""
+        task_id = generate_id()
+        d = self._make_dir(task_id)
+        repos.directions.save(d)
+        repos.directions.claim(task_id, "fuzz_target", "agent_1")
+
+        repos.directions.complete(d.direction_id, sp_count=7, functions_analyzed=42)
+        found = repos.directions.find_by_id(d.direction_id)
+        assert found.status == DirectionStatus.COMPLETED.value
+        assert found.sp_count == 7
+        assert found.functions_analyzed == 42
+
+    def test_skip_low_value_direction(self, repos):
+        """Agent can skip a direction deemed not worth analyzing."""
+        task_id = generate_id()
+        d = self._make_dir(task_id, risk_level=RiskLevel.LOW.value)
+        repos.directions.save(d)
+
+        repos.directions.skip(d.direction_id, reason="too simple")
+        found = repos.directions.find_by_id(d.direction_id)
+        assert found.status == DirectionStatus.SKIPPED.value
+
+    def test_release_claim_on_agent_crash(self, repos):
+        """If an agent crashes, its claimed direction returns to PENDING."""
+        task_id = generate_id()
+        d = self._make_dir(task_id)
+        repos.directions.save(d)
+        repos.directions.claim(task_id, "fuzz_target", "agent_1")
+
+        repos.directions.release_claim(d.direction_id)
+
+        found = repos.directions.find_by_id(d.direction_id)
+        assert found.status == DirectionStatus.PENDING.value
+        # Another agent can now claim it
+        reclaimed = repos.directions.claim(task_id, "fuzz_target", "agent_2")
+        assert reclaimed is not None
+
+    def test_is_all_complete_mixed_states(self, repos):
+        """is_all_complete only True when no PENDING or IN_PROGRESS remain."""
+        task_id = generate_id()
+        d1 = self._make_dir(task_id, name="d1")
+        d2 = self._make_dir(task_id, name="d2")
+        d3 = self._make_dir(task_id, name="d3")
+        for d in [d1, d2, d3]:
+            repos.directions.save(d)
+
+        assert repos.directions.is_all_complete(task_id) is False
+
+        repos.directions.complete(d1.direction_id)
+        repos.directions.skip(d2.direction_id)
+        # d3 still pending
+        assert repos.directions.is_all_complete(task_id) is False
+
+        repos.directions.complete(d3.direction_id)
+        assert repos.directions.is_all_complete(task_id) is True
+
+    def test_find_by_fuzzer_isolates_fuzzers(self, repos):
+        """Directions from different fuzzers don't mix."""
+        task_id = generate_id()
+        d1 = self._make_dir(task_id, fuzzer="fuzz1", name="dir_for_fuzz1")
+        d2 = self._make_dir(task_id, fuzzer="fuzz2", name="dir_for_fuzz2")
+        repos.directions.save(d1)
+        repos.directions.save(d2)
+
+        found = repos.directions.find_by_fuzzer(task_id, "fuzz1")
+        assert len(found) == 1
+        assert found[0].direction_id == d1.direction_id
+
+    def test_delete_by_task_removes_all(self, repos):
+        """Cleaning up after task cancellation."""
+        task_id = generate_id()
+        for i in range(3):
+            repos.directions.save(self._make_dir(task_id, name=f"dir_{i}"))
+
+        deleted = repos.directions.delete_by_task(task_id)
+        assert deleted == 3
+        assert repos.directions.count({"task_id": ObjectId(task_id)}) == 0
+
+
+# =========================================================================
+# POV Discovery and Reporting
+# =========================================================================
+
+
+class TestPOVDiscovery:
+    """POV repository serves the POV discovery and deduplication pipeline."""
+
+    def test_find_by_task_uses_objectid(self, repos):
+        """POVs stored with ObjectId(task_id) must be findable by string task_id."""
+        task_id = generate_id()
+        other_task = generate_id()
+        p1 = POV(task_id=task_id, harness_name="h1")
+        p2 = POV(task_id=task_id, harness_name="h2")
+        p_other = POV(task_id=other_task, harness_name="h1")
+        for p in [p1, p2, p_other]:
+            repos.povs.save(p)
+
+        found = repos.povs.find_by_task(task_id)
+        assert len(found) == 2
+        assert {p.pov_id for p in found} == {p1.pov_id, p2.pov_id}
+
+    def test_successful_excludes_inactive_and_failed(self, repos):
+        """Only active + successful POVs count toward task score."""
+        task_id = generate_id()
+        active_success = POV(task_id=task_id, is_active=True, is_successful=True)
+        active_fail = POV(task_id=task_id, is_active=True, is_successful=False)
+        inactive_success = POV(task_id=task_id, is_active=False, is_successful=True)
+        for p in [active_success, active_fail, inactive_success]:
+            repos.povs.save(p)
+
+        found = repos.povs.find_successful_by_task(task_id)
+        assert len(found) == 1
+        assert found[0].pov_id == active_success.pov_id
+
+    def test_find_by_harness_for_worker_isolation(self, repos):
+        """Each worker queries POVs for its own harness."""
+        task_id = generate_id()
+        p1 = POV(task_id=task_id, harness_name="fuzz_target1")
+        p2 = POV(task_id=task_id, harness_name="fuzz_target2")
+        repos.povs.save(p1)
+        repos.povs.save(p2)
+
+        found = repos.povs.find_by_harness(task_id, "fuzz_target1")
+        assert len(found) == 1
+        assert found[0].harness_name == "fuzz_target1"
+
+    def test_deactivate_removes_from_active_query(self, repos):
+        """Deactivated POV no longer appears in active/successful queries."""
+        task_id = generate_id()
+        pov = POV(task_id=task_id, is_active=True, is_successful=True)
+        repos.povs.save(pov)
+
+        repos.povs.deactivate(pov.pov_id)
+
+        assert len(repos.povs.find_active_by_task(task_id)) == 0
+        assert len(repos.povs.find_successful_by_task(task_id)) == 0
+
+        # But still findable by direct ID
+        found = repos.povs.find_by_id(pov.pov_id)
+        assert found is not None
+        assert found.is_active is False
+
+
+# =========================================================================
+# Patch Verification Pipeline
+# =========================================================================
+
+
+class TestPatchVerification:
+    """Patches go through apply → compile → pov → test checks."""
+
+    def test_only_fully_verified_patches_are_valid(self, repos):
+        """find_valid_by_task requires all 4 checks to be True."""
+        task_id = generate_id()
+        full_pass = Patch(
+            task_id=task_id, apply_check=True, compilation_check=True,
+            pov_check=True, test_check=True,
+        )
+        partial_pass = Patch(
+            task_id=task_id, apply_check=True, compilation_check=True,
+            pov_check=True, test_check=False,  # test failed
+        )
+        repos.patches.save(full_pass)
+        repos.patches.save(partial_pass)
+
+        valid = repos.patches.find_valid_by_task(task_id)
+        assert len(valid) == 1
+        assert valid[0].patch_id == full_pass.patch_id
+
+    def test_inactive_patch_excluded_from_valid(self, repos):
+        """Deactivated patches are not returned even if all checks pass."""
+        task_id = generate_id()
+        pa = Patch(
+            task_id=task_id, apply_check=True, compilation_check=True,
+            pov_check=True, test_check=True, is_active=False,
+        )
+        repos.patches.save(pa)
+
+        assert len(repos.patches.find_valid_by_task(task_id)) == 0
+
+    def test_incremental_check_updates(self, repos):
+        """Checks are updated incrementally as each stage completes."""
+        task_id = generate_id()
+        pa = Patch(task_id=task_id)
+        repos.patches.save(pa)
+
+        # Stage 1: apply check passes
+        repos.patches.update_checks(pa.patch_id, apply=True)
+        found = repos.patches.find_by_id(pa.patch_id)
+        assert found.apply_check is True
+        assert found.compilation_check is False
+
+        # Stage 2: compile check passes
+        repos.patches.update_checks(pa.patch_id, compile=True)
+        found = repos.patches.find_by_id(pa.patch_id)
+        assert found.apply_check is True
+        assert found.compilation_check is True
+        assert found.pov_check is False
+
+
+# =========================================================================
+# Worker Lifecycle
+# =========================================================================
+
+
+class TestWorkerLifecycle:
+    """Workers progress: pending → building → running → completed."""
+
+    def test_worker_state_progression_with_results(self, repos):
+        """Worker goes through states and accumulates results."""
+        task_id = generate_id()
+        w = Worker(task_id=task_id, fuzzer="fuzz1", sanitizer="address",
+                   project_name="openssl")
+        repos.workers.save(w)
+
+        repos.workers.update_status(w.worker_id, "running")
+        repos.workers.update_strategy(w.worker_id, "fullscan")
+        repos.workers.update_strategy(w.worker_id, "pov_targeted")
+        repos.workers.update_results(w.worker_id, povs=3, patches=1)
+
+        found = repos.workers.find_by_id(w.worker_id)
+        assert found.status == WorkerStatus.RUNNING
+        assert found.current_strategy == "pov_targeted"
+        assert found.strategy_history == ["fullscan", "pov_targeted"]
+        assert found.pov_generated == 3
+        assert found.patch_generated == 1
+
+    def test_find_by_fuzzer_exact_match(self, repos):
+        """find_by_fuzzer matches on task_id + fuzzer + sanitizer triple."""
+        task_id = generate_id()
+        w_addr = Worker(task_id=task_id, fuzzer="fuzz1", sanitizer="address")
+        w_mem = Worker(task_id=task_id, fuzzer="fuzz1", sanitizer="memory")
+        repos.workers.save(w_addr)
+        repos.workers.save(w_mem)
+
+        found = repos.workers.find_by_fuzzer(task_id, "fuzz1", "address")
+        assert found.worker_id == w_addr.worker_id
+
+        assert repos.workers.find_by_fuzzer(task_id, "fuzz1", "undefined") is None
+
+    def test_find_by_task_isolates_tasks(self, repos):
+        """Workers from different tasks don't mix."""
+        tid_a = generate_id()
+        tid_b = generate_id()
+        w1 = Worker(task_id=tid_a, fuzzer="f1")
+        w2 = Worker(task_id=tid_a, fuzzer="f2")
+        w_other = Worker(task_id=tid_b, fuzzer="f1")
+        for w in [w1, w2, w_other]:
+            repos.workers.save(w)
+
+        found = repos.workers.find_by_task(tid_a)
+        assert len(found) == 2
+
+
+# =========================================================================
+# Fuzzer Build Tracking
+# =========================================================================
+
+
+class TestFuzzerBuild:
+    """Fuzzer build status drives which fuzzers are available for analysis."""
+
+    def test_find_successful_excludes_failed(self, repos):
+        """Only fuzzers with status='success' are used for analysis."""
+        task_id = generate_id()
+        f_ok = Fuzzer(task_id=task_id, fuzzer_name="f1", status=FuzzerStatus.SUCCESS)
+        f_fail = Fuzzer(task_id=task_id, fuzzer_name="f2", status=FuzzerStatus.FAILED)
+        f_building = Fuzzer(task_id=task_id, fuzzer_name="f3", status=FuzzerStatus.BUILDING)
+        for f in [f_ok, f_fail, f_building]:
+            repos.fuzzers.save(f)
+
+        found = repos.fuzzers.find_successful_by_task(task_id)
+        assert len(found) == 1
+        assert found[0].fuzzer_name == "f1"
+
+    def test_find_by_name_with_objectid_task(self, repos):
+        """find_by_name correctly queries with ObjectId(task_id)."""
+        task_id = generate_id()
+        f = Fuzzer(task_id=task_id, fuzzer_name="fuzz_target1")
+        repos.fuzzers.save(f)
+
+        found = repos.fuzzers.find_by_name(task_id, "fuzz_target1")
+        assert found is not None
+        assert found.fuzzer_id == f.fuzzer_id
+        assert found.task_id == task_id
+
+    def test_update_status_records_binary_path(self, repos):
+        """After successful build, binary_path is stored for fuzzer execution."""
+        f = Fuzzer(task_id=generate_id(), fuzzer_name="fuzz1")
+        repos.fuzzers.save(f)
+
+        repos.fuzzers.update_status(f.fuzzer_id, "success", binary_path="/out/fuzz1")
+        found = repos.fuzzers.find_by_id(f.fuzzer_id)
+        assert found.status == FuzzerStatus.SUCCESS
+        assert found.binary_path == "/out/fuzz1"
+
+
+# =========================================================================
+# Function Analysis Tracking (composite string key)
+# =========================================================================
+
+
+class TestFunctionAnalysis:
+    """Functions track which directions have analyzed them to avoid redundant work."""
+
+    def test_composite_key_lookup(self, repos):
+        """Function._id = '{task_id}_{name}', find_by_name constructs this key."""
+        task_id = generate_id()
+        fn = Function(
+            task_id=task_id, name="vuln_func", file_path="src/vuln.c",
+            start_line=10, end_line=50, content="void vuln_func() {}",
+            reached_by_fuzzers=["fuzz1"],
+        )
+        repos.functions.save(fn)
+
+        assert fn.function_id == f"{task_id}_vuln_func"
+        found = repos.functions.find_by_name(task_id, "vuln_func")
+        assert found is not None
+        assert found.task_id == task_id
+        assert found.name == "vuln_func"
+
+    def test_analysis_priority_ordering(self, repos):
+        """get_functions_for_analysis returns unanalyzed functions first.
+
+        This drives coverage efficiency: agents analyze new functions before
+        re-visiting already-analyzed ones.
+        Priority: never analyzed > analyzed by other direction > analyzed by this direction.
+        """
+        task_id = generate_id()
+        dir_a = generate_id()
+        dir_b = generate_id()
+
+        fn_fresh = Function(
+            task_id=task_id, name="fresh_func", file_path="a.c",
+            reached_by_fuzzers=["fuzz1"],
+        )
+        fn_other = Function(
+            task_id=task_id, name="analyzed_by_other", file_path="a.c",
+            reached_by_fuzzers=["fuzz1"],
+            analyzed_by_directions=[dir_b],
+        )
+        fn_done = Function(
+            task_id=task_id, name="already_analyzed", file_path="a.c",
+            reached_by_fuzzers=["fuzz1"],
+            analyzed_by_directions=[dir_a],
+        )
+        for fn in [fn_fresh, fn_other, fn_done]:
+            repos.functions.save(fn)
+
+        results = repos.functions.get_functions_for_analysis(task_id, "fuzz1", dir_a)
+        assert len(results) == 3
+        assert results[0].name == "fresh_func"
+        assert results[1].name == "analyzed_by_other"
+        assert results[2].name == "already_analyzed"
+
+    def test_mark_analyzed_is_idempotent(self, repos):
+        """$addToSet ensures marking the same direction twice doesn't duplicate."""
+        task_id = generate_id()
+        direction_id = generate_id()
+        fn = Function(
+            task_id=task_id, name="func_a", file_path="a.c",
+            reached_by_fuzzers=["fuzz1"],
+        )
+        repos.functions.save(fn)
+
+        repos.functions.mark_analyzed_by_direction(fn.function_id, direction_id)
+        repos.functions.mark_analyzed_by_direction(fn.function_id, direction_id)
+
+        found = repos.functions.find_by_name(task_id, "func_a")
+        assert len(found.analyzed_by_directions) == 1
+
+    def test_mark_many_analyzed_batch(self, repos):
+        """Batch-mark multiple functions as analyzed by one direction."""
+        task_id = generate_id()
+        direction_id = generate_id()
+        f1 = Function(task_id=task_id, name="f1", file_path="a.c",
+                      reached_by_fuzzers=["fuzz1"])
+        f2 = Function(task_id=task_id, name="f2", file_path="a.c",
+                      reached_by_fuzzers=["fuzz1"])
+        for fn in [f1, f2]:
+            repos.functions.save(fn)
+
+        updated = repos.functions.mark_many_analyzed(
+            [f1.function_id, f2.function_id], direction_id,
+        )
+        assert updated == 2
+
+        for fn_id in [f1.function_id, f2.function_id]:
+            found = repos.functions.find_by_id(fn_id)
+            assert direction_id in found.analyzed_by_directions
+
+    def test_delete_by_task_cleans_up(self, repos):
+        """When a task is re-run, old function data is cleaned out."""
+        task_id = generate_id()
+        for i in range(3):
+            repos.functions.save(
+                Function(task_id=task_id, name=f"f{i}", file_path="a.c",
+                         reached_by_fuzzers=["fuzz1"])
+            )
+
+        deleted = repos.functions.delete_by_task(task_id)
+        assert deleted == 3
+        assert repos.functions.find_by_task(task_id) == []
+
+
+# =========================================================================
+# Call Graph (composite string key, fuzzer_id as string)
+# =========================================================================
+
+
+class TestCallGraph:
+    """Call graph tracks caller/callee relationships per fuzzer.
+
+    In production, fuzzer_id is typically the fuzzer name (e.g., 'fuzz_target1'),
+    not a 24-char ObjectId hex. Tests use fuzzer names to match real usage.
+    """
+
+    def test_composite_key_lookup(self, repos):
+        """node_id = '{task_id}_{fuzzer_id}_{function_name}'."""
+        task_id = generate_id()
+        node = CallGraphNode(
+            task_id=task_id, fuzzer_id="fuzz_target1",
+            fuzzer_name="fuzz_target1", function_name="main",
+            callers=[], callees=["parse_input"], call_depth=0,
+        )
+        repos.callgraph_nodes.save(node)
+
+        found = repos.callgraph_nodes.find_by_function(task_id, "fuzz_target1", "main")
+        assert found is not None
+        assert found.callees == ["parse_input"]
+
+    def test_callers_and_callees_traversal(self, repos):
+        """find_callers/find_callees return the adjacency lists."""
+        task_id = generate_id()
+        node = CallGraphNode(
+            task_id=task_id, fuzzer_id="fuzz1",
+            fuzzer_name="fuzz1", function_name="process",
+            callers=["main", "init"], callees=["read_buf", "write_out"],
+            call_depth=1,
+        )
+        repos.callgraph_nodes.save(node)
+
+        assert set(repos.callgraph_nodes.find_callers(task_id, "fuzz1", "process")) == {"main", "init"}
+        assert set(repos.callgraph_nodes.find_callees(task_id, "fuzz1", "process")) == {"read_buf", "write_out"}
+
+    def test_find_by_depth_filters_correctly(self, repos):
+        """find_by_depth returns only nodes at the specified depth."""
+        task_id = generate_id()
+        fid = "fuzz1"
+        for depth, name in [(0, "main"), (1, "parse"), (1, "read"), (2, "memcpy")]:
+            repos.callgraph_nodes.save(
+                CallGraphNode(
+                    task_id=task_id, fuzzer_id=fid, fuzzer_name=fid,
+                    function_name=name, call_depth=depth,
+                )
+            )
+
+        depth1 = repos.callgraph_nodes.find_by_depth(task_id, fid, 1)
+        assert len(depth1) == 2
+        assert all(n.call_depth == 1 for n in depth1)
+
+    def test_delete_by_fuzzer_isolates(self, repos):
+        """Deleting one fuzzer's call graph doesn't affect another's."""
+        task_id = generate_id()
+        repos.callgraph_nodes.save(
+            CallGraphNode(task_id=task_id, fuzzer_id="fuzz_a",
+                          fuzzer_name="a", function_name="fn1", call_depth=0)
+        )
+        repos.callgraph_nodes.save(
+            CallGraphNode(task_id=task_id, fuzzer_id="fuzz_b",
+                          fuzzer_name="b", function_name="fn2", call_depth=0)
+        )
+
+        deleted = repos.callgraph_nodes.delete_by_fuzzer(task_id, "fuzz_a")
+        assert deleted == 1
+
+        remaining = repos.callgraph_nodes.find_by_task(task_id)
+        assert len(remaining) == 1
+        assert remaining[0].fuzzer_id == "fuzz_b"
+
+
+# =========================================================================
+# Cross-Cutting Concerns
+# =========================================================================
+
+
+class TestObjectIdRoundtrip:
+    """Verify str→ObjectId→str survives round-trip for all model types.
+
+    This is THE most common source of bugs: code stores ObjectId in MongoDB
+    but queries with string, or vice versa.
+    """
+
+    def test_task_roundtrip(self, repos):
+        task = Task(project_name="test")
+        repos.tasks.save(task)
+        found = repos.tasks.find_by_id(task.task_id)
+        assert found.task_id == task.task_id
+
+    def test_worker_roundtrip(self, repos):
+        w = Worker(task_id=generate_id(), fuzzer="f1")
+        repos.workers.save(w)
+        found = repos.workers.find_by_id(w.worker_id)
+        assert found.worker_id == w.worker_id
+
+    def test_sp_roundtrip(self, repos):
+        sp = SuspiciousPoint(
+            task_id=generate_id(), function_name="f",
+            direction_id=generate_id(),
+            description="d", vuln_type="v",
+        )
+        repos.suspicious_points.save(sp)
+        found = repos.suspicious_points.find_by_id(sp.suspicious_point_id)
+        assert found.suspicious_point_id == sp.suspicious_point_id
+        assert found.task_id == sp.task_id
+        assert found.direction_id == sp.direction_id
+
+    def test_direction_roundtrip(self, repos):
+        d = Direction(task_id=generate_id(), fuzzer="f", name="d")
+        repos.directions.save(d)
+        found = repos.directions.find_by_id(d.direction_id)
+        assert found.direction_id == d.direction_id
+
+    def test_function_composite_key_roundtrip(self, repos):
+        """Function uses '{task_id}_{name}' as _id, not ObjectId."""
+        task_id = generate_id()
+        fn = Function(task_id=task_id, name="func", file_path="a.c",
+                      reached_by_fuzzers=["f1"])
+        repos.functions.save(fn)
+        found = repos.functions.find_by_id(fn.function_id)
+        assert found.function_id == fn.function_id
+        assert found.task_id == task_id
+
+
+class TestRepositoryManager:
+    def test_lazy_singleton_per_repo(self, repos):
+        """Each property returns the same instance on repeated access."""
+        assert repos.tasks is repos.tasks
+        assert repos.povs is repos.povs
+        assert repos.suspicious_points is repos.suspicious_points
+
+    def test_all_nine_repos_accessible(self, repos):
+        """All 9 repository types are accessible."""
+        repo_names = [
+            "tasks", "povs", "patches", "suspicious_points",
+            "directions", "workers", "fuzzers", "functions", "callgraph_nodes",
+        ]
+        for name in repo_names:
+            assert getattr(repos, name) is not None

--- a/FuzzingBrain-v2/v2/tests/test_sp_creation.py
+++ b/FuzzingBrain-v2/v2/tests/test_sp_creation.py
@@ -1,0 +1,365 @@
+"""
+Suspicious Point Creation Tests
+
+Tests the SP creation flow: LLM tool call → create_suspicious_point_impl → client → DB.
+
+Business invariants under test:
+1. No direction_id in context → create SP blocked (Layer A guard)
+2. LLM params (function_name, vuln_type, description, score) forwarded correctly to client
+3. harness_name/sanitizer/direction_id/agent_id come from ContextVar, not LLM
+4. New SP defaults to PENDING_VERIFY status so claim_for_verify() can pick it up
+5. created_by_agent_id is set from context (not LLM)
+6. sources array contains the correct harness/sanitizer pair
+"""
+
+import mongomock
+import pytest
+from unittest.mock import patch, MagicMock
+
+from bson import ObjectId
+
+from fuzzingbrain.core.models.suspicious_point import SuspiciousPoint, SPStatus
+from fuzzingbrain.db.repository import SuspiciousPointRepository
+from fuzzingbrain.tools.suspicious_points import (
+    create_suspicious_point_impl,
+    set_sp_context,
+    set_sp_agent_id,
+    get_sp_context,
+)
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _mock_client_create_success(sp_id=None):
+    """Return a mock AnalysisClient whose create_suspicious_point returns success."""
+    client = MagicMock()
+    sid = sp_id or str(ObjectId())
+    client.create_suspicious_point.return_value = {
+        "id": sid,
+        "created": True,
+        "merged": False,
+    }
+    return client
+
+
+@pytest.fixture
+def sp_repo():
+    """SuspiciousPointRepository backed by mongomock."""
+    client = mongomock.MongoClient()
+    db = client["test_fuzzingbrain"]
+    return SuspiciousPointRepository(db)
+
+
+# =========================================================================
+# Tests: Direction guard (Layer A)
+# =========================================================================
+
+
+class TestDirectionGuard:
+    """
+    Business rule: only SP Finding agents (with direction_id set) may create SPs.
+    SPVerifier and POVAgent must NOT be able to create SPs even if they
+    somehow get access to the tool.
+    """
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_no_direction_id_blocks_creation(self, _ensure, mock_get_client):
+        """Without direction_id in context, create must fail."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        # Set context WITHOUT direction_id (simulates SPVerifier/POVAgent)
+        set_sp_context("fuzz_png", "address", direction_id="", agent_id=str(ObjectId()))
+
+        result = create_suspicious_point_impl(
+            function_name="parse_chunk",
+            vuln_type="buffer-overflow",
+            description="heap overflow in chunk parser",
+        )
+
+        assert result["success"] is False
+        assert "no direction_id" in result["error"]
+        client.create_suspicious_point.assert_not_called()
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_with_direction_id_allows_creation(self, _ensure, mock_get_client):
+        """With direction_id set (SPG agent), create must succeed."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        direction_id = str(ObjectId())
+        set_sp_context("fuzz_png", "address", direction_id=direction_id)
+
+        result = create_suspicious_point_impl(
+            function_name="parse_chunk",
+            vuln_type="buffer-overflow",
+            description="heap overflow",
+        )
+
+        assert result["success"] is True
+        client.create_suspicious_point.assert_called_once()
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_set_sp_agent_id_does_not_bypass_guard(self, _ensure, mock_get_client):
+        """
+        set_sp_agent_id() only sets agent_id, not direction_id.
+        An agent that only calls set_sp_agent_id (SPVerifier) must still be blocked.
+        """
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        # Simulate SPVerifier: set_sp_context without direction, then set_sp_agent_id
+        set_sp_context("fuzz_png", "address", direction_id="")
+        set_sp_agent_id(str(ObjectId()))
+
+        result = create_suspicious_point_impl(
+            function_name="parse_chunk",
+            vuln_type="buffer-overflow",
+            description="test",
+        )
+
+        assert result["success"] is False
+        client.create_suspicious_point.assert_not_called()
+
+
+# =========================================================================
+# Tests: LLM params → client field flow
+# =========================================================================
+
+
+class TestSPFieldFlow:
+    """
+    Business rule: LLM-provided params must reach the client unchanged.
+    System-injected fields (harness, sanitizer, direction_id, agent_id)
+    must come from ContextVar.
+    """
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_llm_params_forwarded_to_client(self, _ensure, mock_get_client):
+        """All LLM-provided fields must arrive at the client."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        direction_id = str(ObjectId())
+        set_sp_context("fuzz_png", "address", direction_id=direction_id)
+
+        create_suspicious_point_impl(
+            function_name="decompress_data",
+            vuln_type="use-after-free",
+            description="UAF after realloc in decompression loop",
+            score=0.85,
+            important_controlflow=[{"type": "function", "name": "realloc", "location": "line 42"}],
+        )
+
+        kw = client.create_suspicious_point.call_args[1]
+        assert kw["function_name"] == "decompress_data"
+        assert kw["vuln_type"] == "use-after-free"
+        assert kw["description"] == "UAF after realloc in decompression loop"
+        assert kw["score"] == 0.85
+        assert kw["important_controlflow"] == [
+            {"type": "function", "name": "realloc", "location": "line 42"}
+        ]
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_context_fields_injected_from_contextvar(self, _ensure, mock_get_client):
+        """harness_name, sanitizer, direction_id, agent_id must come from ContextVar."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        direction_id = str(ObjectId())
+        agent_id = str(ObjectId())
+        set_sp_context("fuzz_png", "address", direction_id=direction_id, agent_id=agent_id)
+
+        create_suspicious_point_impl(
+            function_name="f",
+            vuln_type="buffer-overflow",
+            description="d",
+        )
+
+        kw = client.create_suspicious_point.call_args[1]
+        assert kw["harness_name"] == "fuzz_png"
+        assert kw["sanitizer"] == "address"
+        assert kw["direction_id"] == direction_id
+        assert kw["agent_id"] == agent_id
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_different_worker_different_context(self, _ensure, mock_get_client):
+        """Switching context must change harness/sanitizer in subsequent calls."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        d1 = str(ObjectId())
+        set_sp_context("fuzz_png", "address", direction_id=d1)
+        create_suspicious_point_impl(
+            function_name="f1", vuln_type="bof", description="d1"
+        )
+        first = client.create_suspicious_point.call_args[1]
+
+        d2 = str(ObjectId())
+        set_sp_context("fuzz_icc", "memory", direction_id=d2)
+        create_suspicious_point_impl(
+            function_name="f2", vuln_type="uaf", description="d2"
+        )
+        second = client.create_suspicious_point.call_args[1]
+
+        assert first["harness_name"] == "fuzz_png"
+        assert first["sanitizer"] == "address"
+        assert second["harness_name"] == "fuzz_icc"
+        assert second["sanitizer"] == "memory"
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_default_score_is_half(self, _ensure, mock_get_client):
+        """If LLM doesn't provide score, default is 0.5."""
+        client = _mock_client_create_success()
+        mock_get_client.return_value = client
+
+        set_sp_context("fuzz_png", "address", direction_id=str(ObjectId()))
+
+        create_suspicious_point_impl(
+            function_name="f",
+            vuln_type="bof",
+            description="d",
+            # score not provided
+        )
+
+        assert client.create_suspicious_point.call_args[1]["score"] == 0.5
+
+
+# =========================================================================
+# Tests: SP initial state in DB
+# =========================================================================
+
+
+class TestSPInitialState:
+    """
+    Business rule: a newly created SP must have status=PENDING_VERIFY.
+    claim_for_verify() queries for this status — wrong initial status = dead SP.
+    Also: created_by_agent_id and sources must be correctly populated.
+    """
+
+    def test_sp_model_defaults_to_pending_verify(self):
+        """SuspiciousPoint() defaults to PENDING_VERIFY."""
+        sp = SuspiciousPoint()
+        assert sp.status == "pending_verify"
+
+    def test_sp_model_defaults_unchecked(self):
+        """New SP must be is_checked=False, is_real=False, is_important=False."""
+        sp = SuspiciousPoint()
+        assert sp.is_checked is False
+        assert sp.is_real is False
+        assert sp.is_important is False
+
+    def test_sp_saved_with_pending_verify_found_by_claim(self, sp_repo):
+        """Save SP → claim_for_verify must find it."""
+        task_id = str(ObjectId())
+        sp = SuspiciousPoint(
+            task_id=task_id,
+            function_name="parse_chunk",
+            description="heap overflow",
+            vuln_type="buffer-overflow",
+            score=0.8,
+            sources=[{"harness_name": "fuzz_png", "sanitizer": "address"}],
+        )
+        sp_repo.save(sp)
+
+        claimed = sp_repo.claim_for_verify(
+            task_id=task_id,
+            processor_id=str(ObjectId()),
+        )
+
+        assert claimed is not None
+        assert claimed.function_name == "parse_chunk"
+
+    def test_created_by_agent_id_persisted(self, sp_repo):
+        """created_by_agent_id from server must round-trip through DB."""
+        task_id = str(ObjectId())
+        agent_id = str(ObjectId())
+
+        sp = SuspiciousPoint(
+            task_id=task_id,
+            function_name="f",
+            created_by_agent_id=agent_id,
+            sources=[{"harness_name": "fuzz_png", "sanitizer": "address"}],
+        )
+        sp_repo.save(sp)
+
+        found = sp_repo.find_by_task(task_id)
+        assert len(found) == 1
+        assert found[0].created_by_agent_id == agent_id
+
+    def test_sources_contain_harness_and_sanitizer(self, sp_repo):
+        """The sources array must record which harness/sanitizer discovered this SP."""
+        task_id = str(ObjectId())
+        sp = SuspiciousPoint(
+            task_id=task_id,
+            function_name="f",
+            sources=[{"harness_name": "fuzz_png", "sanitizer": "address"}],
+        )
+        sp_repo.save(sp)
+
+        found = sp_repo.find_by_task(task_id)
+        assert len(found) == 1
+        assert found[0].sources == [{"harness_name": "fuzz_png", "sanitizer": "address"}]
+
+    def test_direction_id_persisted(self, sp_repo):
+        """SP must record which direction it belongs to."""
+        task_id = str(ObjectId())
+        direction_id = str(ObjectId())
+
+        sp = SuspiciousPoint(
+            task_id=task_id,
+            function_name="f",
+            direction_id=direction_id,
+            sources=[{"harness_name": "fuzz_png", "sanitizer": "address"}],
+        )
+        sp_repo.save(sp)
+
+        found = sp_repo.find_by_task(task_id)
+        assert len(found) == 1
+        assert found[0].direction_id == direction_id
+
+
+# =========================================================================
+# Tests: SP context isolation
+# =========================================================================
+
+
+class TestSPContextIsolation:
+    """
+    Business rule: set_sp_context only affects current context.
+    set_sp_agent_id sets agent_id without touching direction_id.
+    """
+
+    def test_set_sp_agent_id_preserves_direction_id(self):
+        """set_sp_agent_id must NOT clear direction_id."""
+        direction_id = str(ObjectId())
+        set_sp_context("fuzz_png", "address", direction_id=direction_id)
+
+        # Agent startup calls set_sp_agent_id
+        new_agent_id = str(ObjectId())
+        set_sp_agent_id(new_agent_id)
+
+        _, _, ctx_direction, ctx_agent = get_sp_context()
+        assert ctx_direction == direction_id, "direction_id must not be cleared"
+        assert ctx_agent == new_agent_id
+
+    def test_set_sp_context_replaces_all_fields(self):
+        """set_sp_context replaces everything including direction_id."""
+        set_sp_context("fuzz_png", "address", direction_id="old_dir", agent_id="old_agent")
+        set_sp_context("fuzz_icc", "memory", direction_id="new_dir", agent_id="new_agent")
+
+        harness, san, direction, agent = get_sp_context()
+        assert harness == "fuzz_icc"
+        assert san == "memory"
+        assert direction == "new_dir"
+        assert agent == "new_agent"

--- a/FuzzingBrain-v2/v2/tests/test_sp_verify.py
+++ b/FuzzingBrain-v2/v2/tests/test_sp_verify.py
@@ -1,0 +1,434 @@
+"""
+SP Verification Tests
+
+Tests the verify flow: claim_for_verify → SPVerifier updates → complete_verify → status routing.
+
+Business invariants under test:
+1. claim_for_verify atomically transitions PENDING_VERIFY → VERIFYING
+2. complete_verify routes: is_important + score >= threshold → PENDING_POV, else VERIFIED
+3. pov_guidance is REQUIRED when is_important=True (even via _impl path)
+4. verified_by_agent_id is set when agent calls update with is_checked=True
+5. claim priority: is_important DESC, score DESC, created_at ASC
+6. complete_verify releases processor_id (lock)
+"""
+
+import mongomock
+import pytest
+from unittest.mock import patch, MagicMock
+
+from bson import ObjectId
+
+from fuzzingbrain.core.models.suspicious_point import SuspiciousPoint, SPStatus
+from fuzzingbrain.db.repository import SuspiciousPointRepository
+from fuzzingbrain.tools.suspicious_points import (
+    update_suspicious_point_impl,
+    set_sp_context,
+)
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _make_sp(task_id, function_name="parse_chunk", score=0.7, status=None):
+    """Create an SP for testing."""
+    sp = SuspiciousPoint(
+        task_id=task_id,
+        function_name=function_name,
+        description=f"potential overflow in {function_name}",
+        vuln_type="buffer-overflow",
+        score=score,
+        sources=[{"harness_name": "fuzz_png", "sanitizer": "address"}],
+    )
+    if status:
+        sp.status = status
+    return sp
+
+
+@pytest.fixture
+def sp_repo():
+    """SuspiciousPointRepository backed by mongomock."""
+    client = mongomock.MongoClient()
+    db = client["test_fuzzingbrain"]
+    return SuspiciousPointRepository(db)
+
+
+# =========================================================================
+# Tests: claim_for_verify
+# =========================================================================
+
+
+class TestClaimForVerify:
+    """
+    Business rule: claim_for_verify atomically transitions SP from
+    PENDING_VERIFY → VERIFYING and sets processor_id.
+    """
+
+    def test_claim_transitions_to_verifying(self, sp_repo):
+        """Claimed SP must have status=VERIFYING."""
+        task_id = str(ObjectId())
+        sp = _make_sp(task_id)
+        sp_repo.save(sp)
+
+        claimed = sp_repo.claim_for_verify(task_id, processor_id=str(ObjectId()))
+
+        assert claimed is not None
+        assert claimed.status == SPStatus.VERIFYING.value
+
+    def test_claim_sets_processor_id(self, sp_repo):
+        """Claimed SP must have processor_id set to the claiming agent."""
+        task_id = str(ObjectId())
+        agent_id = str(ObjectId())
+        sp = _make_sp(task_id)
+        sp_repo.save(sp)
+
+        claimed = sp_repo.claim_for_verify(task_id, processor_id=agent_id)
+
+        assert claimed.processor_id == agent_id
+
+    def test_already_claimed_not_double_claimed(self, sp_repo):
+        """Once claimed (VERIFYING), a second claim must return None."""
+        task_id = str(ObjectId())
+        sp = _make_sp(task_id)
+        sp_repo.save(sp)
+
+        first = sp_repo.claim_for_verify(task_id, processor_id=str(ObjectId()))
+        second = sp_repo.claim_for_verify(task_id, processor_id=str(ObjectId()))
+
+        assert first is not None
+        assert second is None
+
+    def test_claim_priority_important_first(self, sp_repo):
+        """is_important=True SP must be claimed before is_important=False."""
+        task_id = str(ObjectId())
+
+        normal = _make_sp(task_id, function_name="normal", score=0.9)
+        important = _make_sp(task_id, function_name="important", score=0.3)
+        important.is_important = True
+
+        sp_repo.save(normal)
+        sp_repo.save(important)
+
+        claimed = sp_repo.claim_for_verify(task_id, processor_id=str(ObjectId()))
+
+        assert claimed.function_name == "important"
+
+    def test_claim_priority_high_score_first(self, sp_repo):
+        """Among equal importance, higher score claimed first."""
+        task_id = str(ObjectId())
+
+        low = _make_sp(task_id, function_name="low_score", score=0.3)
+        high = _make_sp(task_id, function_name="high_score", score=0.9)
+
+        sp_repo.save(low)
+        sp_repo.save(high)
+
+        claimed = sp_repo.claim_for_verify(task_id, processor_id=str(ObjectId()))
+
+        assert claimed.function_name == "high_score"
+
+
+# =========================================================================
+# Tests: complete_verify status routing
+# =========================================================================
+
+
+class TestCompleteVerifyRouting:
+    """
+    Business rule:
+    - is_important=True + score >= pov_min → PENDING_POV (proceed to POV)
+    - otherwise → VERIFIED (terminal, false positive or low priority)
+    """
+
+    def test_important_high_score_goes_to_pov(self, sp_repo):
+        """is_important=True, score=0.9, proceed_to_pov=True → PENDING_POV."""
+        task_id = str(ObjectId())
+        sp = _make_sp(task_id, status=SPStatus.VERIFYING.value)
+        sp_repo.save(sp)
+
+        sp_repo.complete_verify(
+            sp.suspicious_point_id,
+            is_real=True,
+            score=0.9,
+            is_important=True,
+            proceed_to_pov=True,
+        )
+
+        updated = sp_repo.find_by_id(sp.suspicious_point_id)
+        assert updated.status == SPStatus.PENDING_POV.value
+
+    def test_not_important_stays_verified(self, sp_repo):
+        """is_important=False, proceed_to_pov=False → VERIFIED (terminal)."""
+        task_id = str(ObjectId())
+        sp = _make_sp(task_id, status=SPStatus.VERIFYING.value)
+        sp_repo.save(sp)
+
+        sp_repo.complete_verify(
+            sp.suspicious_point_id,
+            is_real=False,
+            score=0.2,
+            is_important=False,
+            proceed_to_pov=False,
+        )
+
+        updated = sp_repo.find_by_id(sp.suspicious_point_id)
+        assert updated.status == SPStatus.VERIFIED.value
+
+    def test_complete_verify_releases_processor_lock(self, sp_repo):
+        """After complete_verify, processor_id must be None (released)."""
+        task_id = str(ObjectId())
+        sp = _make_sp(task_id, status=SPStatus.VERIFYING.value)
+        sp.processor_id = str(ObjectId())  # locked
+        sp_repo.save(sp)
+
+        sp_repo.complete_verify(
+            sp.suspicious_point_id,
+            is_real=True,
+            score=0.8,
+            proceed_to_pov=True,
+            is_important=True,
+        )
+
+        updated = sp_repo.find_by_id(sp.suspicious_point_id)
+        assert updated.processor_id is None
+
+    def test_complete_verify_sets_is_checked(self, sp_repo):
+        """After complete_verify, is_checked must be True."""
+        task_id = str(ObjectId())
+        sp = _make_sp(task_id, status=SPStatus.VERIFYING.value)
+        sp_repo.save(sp)
+
+        sp_repo.complete_verify(
+            sp.suspicious_point_id,
+            is_real=True,
+            score=0.8,
+        )
+
+        updated = sp_repo.find_by_id(sp.suspicious_point_id)
+        assert updated.is_checked is True
+
+
+# =========================================================================
+# Tests: pov_guidance validation
+# =========================================================================
+
+
+class TestPovGuidanceValidation:
+    """
+    Business rule: when an agent marks a SP as is_important=True,
+    it MUST also provide pov_guidance. Without guidance, the POV agent
+    has no direction on how to exploit the vulnerability.
+
+    The MCP decorator version validates this (line 397-402 in suspicious_points.py).
+    The _impl version (used by MCP factory, which is what agents actually call)
+    must also validate this.
+    """
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_impl_rejects_important_without_guidance(self, _ensure, mock_get_client):
+        """
+        update_suspicious_point_impl must reject is_important=True without pov_guidance.
+
+        This is the path agents actually use (via MCP factory → _impl).
+        """
+        client = MagicMock()
+        client.update_suspicious_point.return_value = {"updated": True}
+        mock_get_client.return_value = client
+
+        set_sp_context("fuzz_png", "address", direction_id=str(ObjectId()))
+
+        result = update_suspicious_point_impl(
+            suspicious_point_id=str(ObjectId()),
+            is_checked=True,
+            is_real=True,
+            is_important=True,
+            score=0.95,
+            verification_notes="Confirmed buffer overflow",
+            pov_guidance=None,  # Missing!
+        )
+
+        assert result["success"] is False, (
+            "update_suspicious_point_impl must reject is_important=True without pov_guidance. "
+            "The MCP decorator version validates this but _impl (used by factory) does not."
+        )
+        client.update_suspicious_point.assert_not_called()
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_impl_accepts_important_with_guidance(self, _ensure, mock_get_client):
+        """is_important=True WITH pov_guidance must succeed."""
+        client = MagicMock()
+        client.update_suspicious_point.return_value = {"updated": True}
+        mock_get_client.return_value = client
+
+        set_sp_context("fuzz_png", "address", direction_id=str(ObjectId()))
+
+        result = update_suspicious_point_impl(
+            suspicious_point_id=str(ObjectId()),
+            is_checked=True,
+            is_real=True,
+            is_important=True,
+            score=0.95,
+            verification_notes="Confirmed buffer overflow",
+            pov_guidance="Send oversized PNG chunk with length > 0x7fffffff",
+        )
+
+        assert result["success"] is True
+
+    @patch("fuzzingbrain.tools.suspicious_points._get_client")
+    @patch("fuzzingbrain.tools.suspicious_points._ensure_client", return_value=None)
+    def test_impl_allows_not_important_without_guidance(self, _ensure, mock_get_client):
+        """is_important=False does not require pov_guidance."""
+        client = MagicMock()
+        client.update_suspicious_point.return_value = {"updated": True}
+        mock_get_client.return_value = client
+
+        set_sp_context("fuzz_png", "address", direction_id=str(ObjectId()))
+
+        result = update_suspicious_point_impl(
+            suspicious_point_id=str(ObjectId()),
+            is_checked=True,
+            is_real=False,
+            is_important=False,
+            score=0.2,
+            verification_notes="False positive",
+        )
+
+        assert result["success"] is True
+
+
+# =========================================================================
+# Tests: verified_by_agent_id tracking
+# =========================================================================
+
+
+class TestVerifiedByTracking:
+    """
+    Business rule: when an agent verifies an SP (is_checked=True),
+    the server must record which agent did it (verified_by_agent_id).
+    """
+
+    def test_server_sets_verified_by_agent_id(self):
+        """
+        Server _update_suspicious_point (async) must set verified_by_agent_id
+        when is_checked=True and agent_id is provided.
+
+        The conversion agent_id → verified_by_agent_id happens in the async method,
+        which builds the updates dict before passing to _sync.
+        We mock _run_sync to bypass the executor and directly call the sync function.
+        """
+        import asyncio
+        from fuzzingbrain.analyzer.server import AnalysisServer
+
+        repos = MagicMock()
+        repos.suspicious_points.update.return_value = True
+
+        server = AnalysisServer.__new__(AnalysisServer)
+        server.repos = repos
+        server.task_id = str(ObjectId())
+        server._log = lambda *args, **kwargs: None
+
+        # Mock _run_sync to directly call the sync function (bypass executor)
+        async def fake_run_sync(func, *args, **kwargs):
+            return func(*args, **kwargs)
+        server._run_sync = fake_run_sync
+
+        sp_id = str(ObjectId())
+        agent_id = str(ObjectId())
+
+        result = asyncio.run(
+            server._update_suspicious_point(
+                {
+                    "id": sp_id,
+                    "is_checked": True,
+                    "is_real": True,
+                    "score": 0.9,
+                    "agent_id": agent_id,
+                }
+            )
+        )
+
+        # Extract the updates dict that was passed to repo.update
+        call_args = repos.suspicious_points.update.call_args
+        updates = call_args[0][1]
+
+        assert "verified_by_agent_id" in updates
+        assert str(updates["verified_by_agent_id"]) == agent_id
+
+    def test_server_does_not_set_verified_when_not_checked(self):
+        """
+        If is_checked is not set, verified_by_agent_id must NOT be set.
+        """
+        import asyncio
+        from fuzzingbrain.analyzer.server import AnalysisServer
+
+        repos = MagicMock()
+        repos.suspicious_points.update.return_value = True
+
+        server = AnalysisServer.__new__(AnalysisServer)
+        server.repos = repos
+        server.task_id = str(ObjectId())
+        server._log = lambda *args, **kwargs: None
+
+        async def fake_run_sync(func, *args, **kwargs):
+            return func(*args, **kwargs)
+        server._run_sync = fake_run_sync
+
+        sp_id = str(ObjectId())
+        agent_id = str(ObjectId())
+
+        asyncio.run(
+            server._update_suspicious_point(
+                {
+                    "id": sp_id,
+                    "score": 0.5,
+                    "agent_id": agent_id,
+                    # is_checked not set
+                }
+            )
+        )
+
+        call_args = repos.suspicious_points.update.call_args
+        updates = call_args[0][1]
+
+        assert "verified_by_agent_id" not in updates
+
+
+# =========================================================================
+# Tests: release_claim on failure
+# =========================================================================
+
+
+class TestReleaseClaimOnFailure:
+    """
+    Business rule: if verification fails (agent crash, timeout),
+    release_claim must revert SP to PENDING_VERIFY so another agent can retry.
+    """
+
+    def test_release_claim_reverts_to_pending(self, sp_repo):
+        """release_claim → status back to PENDING_VERIFY, processor_id cleared."""
+        task_id = str(ObjectId())
+        sp = _make_sp(task_id, status=SPStatus.VERIFYING.value)
+        sp.processor_id = str(ObjectId())
+        sp_repo.save(sp)
+
+        sp_repo.release_claim(sp.suspicious_point_id, SPStatus.PENDING_VERIFY.value)
+
+        updated = sp_repo.find_by_id(sp.suspicious_point_id)
+        assert updated.status == SPStatus.PENDING_VERIFY.value
+        assert updated.processor_id is None
+
+    def test_released_sp_can_be_reclaimed(self, sp_repo):
+        """After release_claim, another agent must be able to claim it."""
+        task_id = str(ObjectId())
+        sp = _make_sp(task_id, status=SPStatus.VERIFYING.value)
+        sp.processor_id = str(ObjectId())
+        sp_repo.save(sp)
+
+        sp_repo.release_claim(sp.suspicious_point_id, SPStatus.PENDING_VERIFY.value)
+
+        reclaimed = sp_repo.claim_for_verify(task_id, processor_id=str(ObjectId()))
+        assert reclaimed is not None
+        assert reclaimed.suspicious_point_id == sp.suspicious_point_id

--- a/FuzzingBrain-v2/v2/tests/test_tools.py
+++ b/FuzzingBrain-v2/v2/tests/test_tools.py
@@ -61,6 +61,7 @@ class TestUpdateSuspiciousPointParameters:
             score=0.8,
             is_checked=True,
             is_important=True,
+            pov_guidance="Trigger via oversized input to function pointer path",
             reachability_status="pointer_call",
             reachability_multiplier=0.95,
             reachability_reason="Reachable via function pointer",

--- a/FuzzingBrain-v2/v2/tests/test_worker_isolation.py
+++ b/FuzzingBrain-v2/v2/tests/test_worker_isolation.py
@@ -1,0 +1,355 @@
+"""
+Worker Isolation Tests
+
+Simulates real Celery worker process behavior:
+- Celery worker processes are reused across tasks
+- WorkerContext lifecycle: __enter__ creates buffer, __exit__ cleans up
+- LLMClient reads buffer via module-level get_worker_buffer()
+- The real risk: state leaking between sequential tasks in the same process
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+from bson import ObjectId
+
+import pytest
+
+from fuzzingbrain.llms.buffer import (
+    WorkerLLMBuffer,
+    set_worker_buffer,
+    get_worker_buffer,
+)
+from fuzzingbrain.core.models.llm_call import LLMCall
+from fuzzingbrain.worker.context import (
+    WorkerContext,
+    _worker_contexts,
+    _worker_contexts_lock,
+)
+
+
+def _make_call(worker_id: str, task_id: str, cost: float = 0.1) -> LLMCall:
+    """Helper: create an LLMCall bound to a specific worker and task."""
+    return LLMCall(
+        worker_id=worker_id,
+        task_id=task_id,
+        agent_id=str(ObjectId()),
+        model="test-model",
+        cost=cost,
+        input_tokens=100,
+        output_tokens=50,
+    )
+
+
+def _simulate_worker_lifecycle(task_id: str, fuzzer: str, n_calls: int = 3):
+    """
+    Simulate what happens inside a real Celery worker task:
+    WorkerContext enter -> LLM calls via buffer -> WorkerContext exit.
+
+    Returns (worker_id, buffer, flushed_records).
+    """
+    mock_db = MagicMock()
+    buffer = WorkerLLMBuffer(redis_url="", mongo_db=mock_db)
+
+    ctx = WorkerContext(
+        task_id=task_id,
+        fuzzer=fuzzer,
+        sanitizer="address",
+    )
+    ctx._llm_buffer = buffer
+    ctx.started_at = __import__("datetime").datetime.now()
+    ctx.status = "running"
+
+    # Simulate __enter__: start buffer, set as global
+    buffer.start()
+    set_worker_buffer(buffer)
+
+    worker_id = ctx.worker_id
+
+    # Simulate agent LLM calls (this is what LLMClient._record_llm_call does)
+    for i in range(n_calls):
+        current_buffer = get_worker_buffer()
+        current_buffer.record(_make_call(worker_id, task_id, cost=float(i + 1)))
+
+    # Simulate __exit__: stop buffer, clear global
+    buffer.stop()
+    set_worker_buffer(None)
+
+    # Collect what was flushed
+    flushed = []
+    for call_args in mock_db.llm_calls.insert_many.call_args_list:
+        flushed.extend(call_args[0][0])
+
+    return worker_id, mock_db, flushed
+
+
+class TestCeleryProcessReuse:
+    """
+    Simulates the real scenario: a single Celery worker process
+    runs Task A, then Task B sequentially. Tests that Task B
+    gets a clean environment with no leftover state from Task A.
+    """
+
+    def test_task_b_does_not_inherit_task_a_buffer(self):
+        """
+        After Task A's WorkerContext exits, get_worker_buffer() must
+        return None. Task B must not accidentally write to Task A's buffer.
+        """
+        task_a_id = str(ObjectId())
+        task_b_id = str(ObjectId())
+
+        worker_a_id = str(ObjectId())
+        worker_b_id = str(ObjectId())
+
+        # --- Task A lifecycle ---
+        buffer_a = WorkerLLMBuffer(redis_url="", mongo_db=None)
+        set_worker_buffer(buffer_a)
+        buffer_a.record(_make_call(worker_a_id, task_a_id, cost=1.0))
+
+        # Task A exits
+        set_worker_buffer(None)
+
+        # --- Between tasks: this is the state Celery process is in ---
+        assert get_worker_buffer() is None, \
+            "Buffer must be None between tasks — Task B would write to Task A's buffer"
+
+        # --- Task B lifecycle ---
+        buffer_b = WorkerLLMBuffer(redis_url="", mongo_db=None)
+        set_worker_buffer(buffer_b)
+        buffer_b.record(_make_call(worker_b_id, task_b_id, cost=2.0))
+
+        # Verify Task B's buffer has only Task B's records
+        assert len(buffer_b._records) == 1
+        assert buffer_b._records[0]["task_id"] == ObjectId(task_b_id)
+
+        # Verify Task A's buffer still has only Task A's records (not polluted by B)
+        assert len(buffer_a._records) == 1
+        assert buffer_a._records[0]["task_id"] == ObjectId(task_a_id)
+
+        set_worker_buffer(None)
+
+    def test_task_b_records_go_to_task_b_db(self):
+        """
+        Full lifecycle simulation: Task A runs and flushes to DB_A,
+        then Task B runs and flushes to DB_B. No cross-contamination.
+        """
+        task_a_id = str(ObjectId())
+        task_b_id = str(ObjectId())
+
+        worker_a_id, db_a, flushed_a = _simulate_worker_lifecycle(
+            task_a_id, "fuzzer_a", n_calls=2
+        )
+        worker_b_id, db_b, flushed_b = _simulate_worker_lifecycle(
+            task_b_id, "fuzzer_b", n_calls=3
+        )
+
+        # Task A flushed exactly 2 records, all belonging to Task A
+        assert len(flushed_a) == 2
+        for rec in flushed_a:
+            assert rec["task_id"] == ObjectId(task_a_id)
+            assert rec["worker_id"] == ObjectId(worker_a_id)
+
+        # Task B flushed exactly 3 records, all belonging to Task B
+        assert len(flushed_b) == 3
+        for rec in flushed_b:
+            assert rec["task_id"] == ObjectId(task_b_id)
+            assert rec["worker_id"] == ObjectId(worker_b_id)
+
+        # Global buffer is clean after both tasks
+        assert get_worker_buffer() is None
+
+    def test_buffer_stop_flushes_remaining_records(self):
+        """
+        When WorkerContext.__exit__ calls buffer.stop(), all buffered
+        records must be flushed to MongoDB. Nothing should be lost.
+        """
+        task_id = str(ObjectId())
+        mock_db = MagicMock()
+        buffer = WorkerLLMBuffer(redis_url="", mongo_db=mock_db)
+        buffer.start()
+        set_worker_buffer(buffer)
+
+        # Record 5 calls (these sit in memory, not yet flushed)
+        for i in range(5):
+            buffer.record(_make_call(str(ObjectId()), task_id, cost=1.0))
+
+        # stop() triggers final flush
+        buffer.stop()
+        set_worker_buffer(None)
+
+        # All 5 records must have been flushed
+        total_flushed = 0
+        for call_args in mock_db.llm_calls.insert_many.call_args_list:
+            total_flushed += len(call_args[0][0])
+        assert total_flushed == 5, \
+            f"Expected 5 records flushed on stop(), got {total_flushed}"
+
+
+class TestWorkerContextExitFailure:
+    """
+    Tests what happens when WorkerContext.__exit__ fails partially.
+    The buffer must still be cleaned up to prevent leaking to the next task.
+    """
+
+    def test_buffer_cleared_even_if_stop_raises(self):
+        """
+        If buffer.stop() raises an exception, set_worker_buffer(None)
+        must still be called. Otherwise the next task inherits a broken buffer.
+
+        This tests the actual __exit__ code path.
+        """
+        task_id = str(ObjectId())
+
+        # Create a buffer that will explode on stop()
+        buffer = WorkerLLMBuffer(redis_url="", mongo_db=None)
+        buffer.start()
+        buffer.stop = MagicMock(side_effect=RuntimeError("flush exploded"))
+
+        set_worker_buffer(buffer)
+
+        # Simulate __exit__ logic (from context.py lines 196-219)
+        try:
+            buffer.cleanup_redis_keys(task_id=task_id, worker_id="fake")
+            buffer.stop()
+        except Exception:
+            pass
+        finally:
+            set_worker_buffer(None)
+
+        # The critical assertion: global buffer must be None
+        assert get_worker_buffer() is None, \
+            "Buffer leaked after stop() failure — next task will write to broken buffer"
+
+    def test_records_not_lost_on_flush_failure(self):
+        """
+        If MongoDB insert_many fails during flush, records must be
+        put back into the buffer (not silently dropped).
+        """
+        task_id = str(ObjectId())
+        mock_db = MagicMock()
+        mock_db.llm_calls.insert_many.side_effect = Exception("MongoDB down")
+
+        buffer = WorkerLLMBuffer(redis_url="", mongo_db=mock_db)
+
+        # Record some calls
+        buffer.record(_make_call(str(ObjectId()), task_id, cost=1.0))
+        buffer.record(_make_call(str(ObjectId()), task_id, cost=2.0))
+
+        # Flush fails
+        count = buffer._flush()
+        assert count == 0, "Flush should return 0 on failure"
+
+        # Records must be put back (not lost)
+        assert len(buffer._records) == 2, \
+            f"Records lost on flush failure: expected 2, got {len(buffer._records)}"
+
+    def test_stop_retries_flush_on_transient_failure(self):
+        """
+        buffer.stop() must retry the final flush. If the first attempt
+        fails but the second succeeds, no records should be lost.
+        """
+        task_id = str(ObjectId())
+        mock_db = MagicMock()
+
+        # First insert_many fails, second succeeds
+        mock_db.llm_calls.insert_many.side_effect = [
+            Exception("transient DB error"),
+            None,  # success
+        ]
+
+        buffer = WorkerLLMBuffer(redis_url="", mongo_db=mock_db)
+        buffer.start()
+
+        buffer.record(_make_call(str(ObjectId()), task_id, cost=1.0))
+        buffer.record(_make_call(str(ObjectId()), task_id, cost=2.0))
+
+        buffer.stop()
+
+        # insert_many called twice (first failed, second succeeded)
+        assert mock_db.llm_calls.insert_many.call_count == 2
+        # All records flushed on second attempt
+        second_call_batch = mock_db.llm_calls.insert_many.call_args_list[1][0][0]
+        assert len(second_call_batch) == 2, \
+            f"Expected 2 records flushed on retry, got {len(second_call_batch)}"
+        # No records left in buffer
+        assert len(buffer._records) == 0
+
+    def test_stop_logs_error_when_all_retries_fail(self):
+        """
+        If all 3 flush attempts fail, stop() must log an error
+        indicating how many records were lost.
+        """
+        task_id = str(ObjectId())
+        mock_db = MagicMock()
+        mock_db.llm_calls.insert_many.side_effect = Exception("DB permanently down")
+
+        buffer = WorkerLLMBuffer(redis_url="", mongo_db=mock_db)
+        buffer.start()
+
+        buffer.record(_make_call(str(ObjectId()), task_id, cost=1.0))
+        buffer.record(_make_call(str(ObjectId()), task_id, cost=2.0))
+        buffer.record(_make_call(str(ObjectId()), task_id, cost=3.0))
+
+        buffer.stop()
+
+        # All 3 retry attempts made
+        assert mock_db.llm_calls.insert_many.call_count == 3
+        # Records still in buffer (lost after buffer is discarded)
+        assert len(buffer._records) == 3, \
+            f"Expected 3 records still in buffer, got {len(buffer._records)}"
+
+
+class TestWorkerContextRegistry:
+    """
+    Tests that the global _worker_contexts registry correctly tracks
+    which workers are active, preventing ghost entries.
+    """
+
+    def setup_method(self):
+        """Clean registry before each test."""
+        with _worker_contexts_lock:
+            _worker_contexts.clear()
+
+    def test_enter_registers_exit_unregisters(self):
+        """Worker appears in registry on enter, disappears on exit."""
+        ctx = WorkerContext(
+            task_id=str(ObjectId()),
+            fuzzer="test_fuzzer",
+            sanitizer="address",
+        )
+
+        # Patch out DB and buffer to avoid real Redis/MongoDB
+        with patch("fuzzingbrain.db.get_database", return_value=MagicMock()), \
+             patch("fuzzingbrain.llms.buffer.WorkerLLMBuffer._connect_redis"):
+
+            ctx.__enter__()
+            assert ctx.worker_id in _worker_contexts, \
+                "Worker not registered on __enter__"
+
+            ctx.__exit__(None, None, None)
+            assert ctx.worker_id not in _worker_contexts, \
+                "Worker still in registry after __exit__ — ghost entry"
+
+    def test_failed_worker_still_unregisters(self):
+        """
+        If a worker fails with an exception, it must still be removed
+        from the registry. Ghost entries would make get_active_workers()
+        return stale data.
+        """
+        ctx = WorkerContext(
+            task_id=str(ObjectId()),
+            fuzzer="test_fuzzer",
+            sanitizer="address",
+        )
+
+        # Manually register (simulating __enter__)
+        with _worker_contexts_lock:
+            _worker_contexts[ctx.worker_id] = ctx
+
+        # Patch DB so __exit__'s _save_to_db succeeds → worker gets unregistered
+        with patch("fuzzingbrain.db.get_database", return_value=MagicMock()):
+            ctx.__exit__(RuntimeError, RuntimeError("boom"), None)
+
+        assert ctx.worker_id not in _worker_contexts, \
+            "Failed worker left ghost entry in registry"
+        assert ctx.status == "failed"
+        assert "boom" in ctx.error


### PR DESCRIPTION
## Summary

- Bug-hunting unit tests discovered and fixed **8 reliability bugs** + **4 ID/validation bugs** in the Worker→Agent pipeline
- Added **265 tests** (all passing) covering context lifecycle, claim orphaning, status transitions, socket isolation, DB operations, and full workflow (dispatch → direction → SP creation → SP verification)

## Bugs Fixed (Round 1: Pipeline Reliability)

| # | Bug | Impact | Fix |
|---|-----|--------|-----|
| 1 | Zombie worker on DB save failure | Task stuck forever | Retry 3x + memory registry fallback |
| 3a | Orphaned SP on verify agent crash | SP stuck in `verifying` | `finally` block with `claimed_sp_id` flag |
| 3b | Direction orphan | Validated release path | Test confirms release→reclaim works |
| 3c | POV same-worker retry blocked | Worker can't retry after crash | `$pull` from `pov_attempted_by` on release |
| 5a | Status backward transition | `completed` → `running` possible | `_STATUS_ORDER` priority check |
| 5b | Double `__exit__` status flip | `completed` overwritten to `failed` | Terminal state guard |
| 6 | Context manager reentrance | Buffer leak, lost LLM records | Idempotent `__enter__` |
| — | Direction leak across phases | SP linked to wrong direction | 3-layer defense (clear + guard + tool isolation) |

## Bugs Fixed (Round 2: ID & Validation)

| # | Bug | Impact | Fix |
|---|-----|--------|-----|
| #88 | SP `to_dict()` missing `suspicious_point_id` key | All SP updates fail — verify agents pass "unknown" as ID, entire verify stage is broken | Added `suspicious_point_id` string key back to `to_dict()` |
| #97 | POV `to_dict()` missing `pov_id` key | POVReportAgent crashes: `'ObjectId' object is not subscriptable` | Added `pov_id` string key back to `to_dict()` |
| — | Direction `to_dict()` missing `direction_id` key | Same pattern as #88/#97 | Added `direction_id` string key back to `to_dict()` |
| — | `update_suspicious_point_impl` missing `pov_guidance` validation | Agents can mark SP as important without providing exploitation guidance for POV | Added same validation that MCP decorator version has |

## Other Improvements

- LLM error logs shortened to one line (type + model) instead of full litellm traceback
- Broken pipe errors on SP creation downgraded from ERROR to WARNING (task shutdown, not a bug)

## Closes

Closes #88
Closes #97

## Files Changed

**Fixes** (15 files):
- `core/models/suspicious_point.py` — restore `suspicious_point_id` in `to_dict()`
- `core/models/pov.py` — restore `pov_id` in `to_dict()`
- `core/models/direction.py` — restore `direction_id` in `to_dict()`
- `tools/suspicious_points.py` — pov_guidance validation + broken pipe handling
- `llms/client.py` — concise error logging
- `worker/context.py` — status guards, retry, reentrance protection
- `worker/pipeline.py` — `finally` blocks for claim release
- `agents/context.py` — retry + reentrance protection
- `db/repository.py` — `release_claim` with `$pull` pov_attempted_by
- `tools/mcp_factory.py` — split SP tool registration
- `agents/base.py`, `sp_verifier.py`, `pov_agent.py` — tool isolation
- `core/dispatcher.py` — Celery SUCCESS detection
- `llms/buffer.py` — flush retry

**Tests** (11 files, 265 tests):
- `test_dispatch_workflow.py` — status filtering, fuzzer filter, pair generation, celery assignment, workspace isolation
- `test_direction_creation.py` — field flow, risk_level validation, pending handoff, planning failure, seed priority
- `test_sp_creation.py` — direction guard, field flow, initial state, context isolation
- `test_sp_verify.py` — claim/complete verify, pov_guidance validation, verified_by tracking, release_claim
- `test_pipeline_chain.py` — ghost workers, orphaned claims, status guards, reentrance
- `test_agent_context_isolation.py` — ContextVar isolation, direction leak, phase transitions
- `test_worker_isolation.py` — buffer lifecycle, registry cleanup
- `test_repository.py` — CRUD, ObjectId, claim/release, pipeline completion
- `test_analyzer_socket_isolation.py` — socket thread safety, reconnection

## Test plan

- [x] All 265 tests pass locally
- [x] Zero ERROR in production logs after fixes
- [ ] CI passes