### PR TITLE
fix: Direction created_by_agent_id always null

### DIFF
--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/base.py
@@ -1044,8 +1044,10 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
 
             # Update SP context with agent_id for tracking SP creator/verifier
             from ..tools.suspicious_points import set_sp_agent_id
+            from ..tools.directions import set_direction_agent_id
 
             set_sp_agent_id(agent_id)
+            set_direction_agent_id(agent_id)
 
             self._log(f"Agent context created: {agent_id}", level="DEBUG")
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/client.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/client.py
@@ -545,6 +545,7 @@ class AnalysisClient:
         call_chain_summary: str = "",
         code_summary: str = "",
         fuzzer: str = "",
+        agent_id: str = "",
     ) -> dict:
         """
         Create a new direction for Full-scan analysis.
@@ -558,6 +559,7 @@ class AnalysisClient:
             call_chain_summary: Summary of call paths
             code_summary: Brief description of what this code does
             fuzzer: Fuzzer name
+            agent_id: Agent ObjectId that created this direction
 
         Returns:
             {"id": "...", "created": True}
@@ -573,6 +575,7 @@ class AnalysisClient:
                 "call_chain_summary": call_chain_summary,
                 "code_summary": code_summary,
                 "fuzzer": fuzzer,
+                "agent_id": agent_id,
             },
         )
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/__init__.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/__init__.py
@@ -60,6 +60,7 @@ from .pov import (
 )
 from .directions import (
     set_direction_context,
+    set_direction_agent_id,
     get_direction_context,
     create_direction,
     list_directions,
@@ -98,6 +99,7 @@ __all__ = [
     "trace_pov",
     # Direction tools (Full-scan)
     "set_direction_context",
+    "set_direction_agent_id",
     "get_direction_context",
     "create_direction",
     "list_directions",

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/directions.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/directions.py
@@ -22,6 +22,9 @@ from .analyzer import _get_client, _ensure_client
 _direction_fuzzer: ContextVar[Optional[str]] = ContextVar(
     "direction_fuzzer", default=None
 )
+_direction_agent_id: ContextVar[Optional[str]] = ContextVar(
+    "direction_agent_id", default=None
+)
 
 
 def set_direction_context(fuzzer: str) -> None:
@@ -35,6 +38,18 @@ def set_direction_context(fuzzer: str) -> None:
     """
     _direction_fuzzer.set(fuzzer)
     logger.debug(f"Direction context set: fuzzer={fuzzer}")
+
+
+def set_direction_agent_id(agent_id: str) -> None:
+    """
+    Set the agent_id for direction tools.
+
+    Called by agents on startup to track which agent created a direction.
+
+    Args:
+        agent_id: Agent ObjectId string
+    """
+    _direction_agent_id.set(agent_id)
 
 
 def get_direction_context() -> Optional[str]:
@@ -70,6 +85,7 @@ def create_direction_impl(
     try:
         client = _get_client()
         fuzzer = get_direction_context() or ""
+        agent_id = _direction_agent_id.get() or ""
 
         result = client.create_direction(
             name=name,
@@ -80,6 +96,7 @@ def create_direction_impl(
             call_chain_summary="",
             code_summary=code_summary,
             fuzzer=fuzzer,
+            agent_id=agent_id,
         )
 
         if result.get("created"):
@@ -189,6 +206,7 @@ def create_direction(
     try:
         client = _get_client()
         fuzzer = get_direction_context() or ""
+        agent_id = _direction_agent_id.get() or ""
 
         result = client.create_direction(
             name=name,
@@ -199,6 +217,7 @@ def create_direction(
             call_chain_summary=call_chain_summary,
             code_summary=code_summary,
             fuzzer=fuzzer,
+            agent_id=agent_id,
         )
 
         if result.get("created"):
@@ -306,6 +325,7 @@ def get_direction(
 __all__ = [
     # Context
     "set_direction_context",
+    "set_direction_agent_id",
     "get_direction_context",
     # Direction tools (MCP decorated)
     "create_direction",


### PR DESCRIPTION
## Summary
- Add `_direction_agent_id` ContextVar to `directions.py` to track which agent creates a direction
- Pass `agent_id` through the full chain: ContextVar → `create_direction_impl` → `client.create_direction` → server
- Server already supported `agent_id` in params (`server.py:1591`) but client never sent it

Closes #96

## Changes
- `tools/directions.py`: Add `_direction_agent_id` ContextVar + `set_direction_agent_id()`
- `analyzer/client.py`: Add `agent_id` parameter to `create_direction()`
- `agents/base.py`: Call `set_direction_agent_id(agent_id)` alongside `set_sp_agent_id()`
- `tools/__init__.py`: Export `set_direction_agent_id`
- `tests/test_direction_creation.py`: 4 new tests for agent_id tracking

## Test plan
- [x] agent_id forwarded from ContextVar to client
- [x] No agent_id defaults to empty string
- [x] Different agents produce different agent_ids
- [x] Server sets created_by_agent_id on Direction object
- [x] Full test suite: 269 passed