### PR TITLE
fix: remove direction_id guard from SP creation

### DIFF
--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/suspicious_points.py
@@ -120,19 +120,6 @@ def create_suspicious_point_impl(
     if err:
         return err
 
-    # Layer A guard: only SP Finding agents (with direction_id set) may create SPs
-    _, _, direction_id, _ = get_sp_context()
-    if not direction_id:
-        logger.warning(
-            f"Blocked SP creation for '{function_name}': no direction_id in context. "
-            "Only SP Finding agents may create suspicious points."
-        )
-        return {
-            "success": False,
-            "error": "Cannot create suspicious point: no direction_id in context. "
-            "Only SP Finding agents are allowed to create suspicious points.",
-        }
-
     try:
         client = _get_client()
         harness_name, sanitizer, direction_id, agent_id = get_sp_context()


### PR DESCRIPTION
## Summary
- Remove `direction_id` guard from `create_suspicious_point` that blocked SP creation in delta mode
- Delta mode has no directions, so requiring `direction_id` caused all SP creations to fail silently
- Agent-level access control (`include_sp_create_tools`) already gates which agents can create SPs

## Test plan
- [x] `py_compile` + `ruff check` + `ruff format` pass
- [ ] CI