### PR TITLE
fix: graceful shutdown with agent cancellation and SSL cleanup

### DIFF
--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/task_processor.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/task_processor.py
@@ -1061,6 +1061,11 @@ class TaskProcessor:
                     }
 
             finally:
+                # Close cached LLM httpx clients (prevents SSL transport warnings)
+                from ..llms import LLMClient
+
+                LLMClient.close_all()
+
                 # Stop Analysis Server
                 if task and task.task_path:
                     from ..analyzer.tasks import stop_analysis_server


### PR DESCRIPTION
## Summary
- Cooperative agent cancellation: `cancel()` flag checked each iteration before LLM calls, avoids broken pipes and wasted API cost
- 4-step `graceful_shutdown()`: cancel agents → grace period → revoke Celery → force-cleanup zombie agents in DB
- All 4 exit paths (timeout / budget / POV target / Ctrl+C) now call `graceful_shutdown()`
- `LLMClient.close_all()` closes cached httpx clients before event loop closes, eliminating SSL transport errors
- Signal handler scoped to current task only — fixes cross-task summary contamination when Ctrl+C before task_id assigned

Closes #87

## Test plan
- [x] `ruff check` + `ruff format --check` pass
- [x] 268/268 tests pass
- [x] Manual test: Ctrl+C during active run → correct summary, no SSL errors
- [x] Manual test: Ctrl+C before task starts → clean exit, no stale summary