### PR TITLE
fix: POVAgent cost optimization and breadth-first SP generation

### DIFF
--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/context.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/context.py
@@ -268,11 +268,9 @@ class AgentContext:
                     "seeds_generated": self.seeds_generated,
                     "pov_iteration": self.pov_iteration,
                     "pov_attempt": self.pov_attempt,
-                    # LLM usage
-                    "llm_calls": self.llm_calls,
-                    "llm_cost": self.llm_cost,
-                    "llm_input_tokens": self.llm_input_tokens,
-                    "llm_output_tokens": self.llm_output_tokens,
+                    # NOTE: llm_calls/llm_cost/llm_input_tokens/llm_output_tokens
+                    # are managed exclusively by WorkerLLMBuffer via $inc.
+                    # Do NOT $set them here — it would overwrite the buffer's increments.
                     "updated_at": datetime.now(),
                 }
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/prompts/pov_agent_prompt.md
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/prompts/pov_agent_prompt.md
@@ -76,6 +76,6 @@ def generate() -> bytes:
 
 ## Limits
 
-- Max 40 create_pov calls
+- Max 20 create_pov calls
 - Each create_pov generates 3 variants
 - Stop when crashed=True

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/prompts/pov_compression_prompt.md
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/prompts/pov_compression_prompt.md
@@ -1,0 +1,44 @@
+Compress the conversation for a POV (Proof-of-Vulnerability) generation agent.
+
+## Goal
+Keep ONLY information that helps generate a crashing input. Remove everything else.
+
+## Task Context (DO NOT include in output)
+{task_context}
+
+## What to Keep
+{compression_criteria}
+
+## Messages to Compress
+{messages_text}
+
+## Output Format
+
+Output ONLY the compressed summary. NO preamble.
+
+For tool calls the agent USED (referenced in its reasoning):
+```
+Tool: <tool_name>(<key_args>)
+Finding: <what the agent learned from this>
+```
+
+For tool calls the agent IGNORED or that produced no useful info:
+**Omit entirely. Do not mention them.**
+
+For agent reasoning/conclusions:
+```
+Agent concluded: <key insight>
+```
+
+For POV attempts:
+```
+POV attempt #N: <generator approach> → <result: crashed/no crash/error> <why it failed if known>
+```
+
+## Rules
+1. REMOVE all tool calls the agent didn't use - do NOT keep stubs
+2. Keep data flow analysis: how input reaches the vulnerable function
+3. Keep all POV attempt results and failure reasons
+4. Keep constraint info: size limits, format requirements, magic bytes
+5. Keep trace results: which functions were reached
+6. Be aggressive - shorter is better

--- a/FuzzingBrain-v2/v2/fuzzingbrain/agents/prompts/verify_suspicious_points_prompt.md
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/agents/prompts/verify_suspicious_points_prompt.md
@@ -1,11 +1,12 @@
 You are a security researcher filtering out obviously wrong suspicious points.
 
-## Your Role: FILTER, Not Deep Verify
+## Your Role: Deep Verify
 
-You are NOT the final judge. Your job is to:
-- Filter out OBVIOUSLY WRONG SPs (truly unreachable, wrong sanitizer type)
-- Let uncertain cases PASS to POV agent for actual testing
-- POV failure is cheap; missing a real bug is expensive
+You are a thorough verifier. Your job is to:
+- Deep analyze each SP to determine if it's a real, exploitable vulnerability
+- Verify the complete path from fuzzer input to the vulnerable code
+- Provide detailed verification notes and POV guidance for confirmed SPs
+- Filter out false positives with concrete evidence
 
 **Key Principle**: When in doubt, let it through. Only mark FP when you are 100% certain.
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/pipeline.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/pipeline.py
@@ -48,8 +48,8 @@ class PipelineConfig:
     max_idle_cycles: int = 10  # Max cycles with no work before agent exits
 
     # POV Agent settings
-    max_iterations: int = 200  # Max agent loop iterations
-    max_pov_attempts: int = 40  # Max POV generation attempts
+    max_iterations: int = 100  # Max agent loop iterations
+    max_pov_attempts: int = 20  # Max POV generation attempts
 
     # Fuzzer settings (for POV verification)
     fuzzer_path: Optional[Path] = None  # Path to fuzzer binary

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_base.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_base.py
@@ -622,8 +622,8 @@ class POVBaseStrategy(BaseStrategy):
             pov_min_score=0.5,  # Minimum score to proceed to POV
             poll_interval=1.0,  # Poll every 1 second
             max_idle_cycles=10,  # Exit after 10 idle cycles
-            max_iterations=200,  # Max POV agent iterations
-            max_pov_attempts=40,  # Max POV generation attempts
+            max_iterations=100,  # Max POV agent iterations
+            max_pov_attempts=20,  # Max POV generation attempts
             fuzzer_path=self.executor.fuzzer_binary_path,
             docker_image=f"gcr.io/oss-fuzz/{self.project_name}",
         )


### PR DESCRIPTION
## Summary
- Breadth-first per-direction SP generation: 4 phases (small/new → small/re → big/new → big/re) across HIGH→MEDIUM→LOW directions
- Fix `$set` overwriting `$inc` on llm_* fields in AgentContext, TaskRepository, WorkerRepository
- POVAgent: switch sync `call_with_tools` to async `acall_with_tools` to unblock event loop
- POVAgent: add context compression at 60K input tokens with POV-specific compression prompt
- POVAgent: inject greedy mode nudge to force early `create_pov` calls
- Reduce POVAgent max_iterations 200→100, max_pov_attempts 40→20
- Change SP verifier role from shallow filter to deep verify

## Test plan
- [x] `ruff check` and `ruff format` pass
- [ ] Run njs fuzz_xml task and compare POVAgent cost vs baseline ($183 → target <$100)
- [ ] Verify context compression fires (max_input_tokens < 100K)
- [ ] Verify greedy nudge injection in POV agent logs
- [ ] Verify SP count increases with budget savings