### PR TITLE
feat: Docker Compose local deployment

### DIFF
--- a/FuzzingBrain-v2/v2/.dockerignore
+++ b/FuzzingBrain-v2/v2/.dockerignore
@@ -1,0 +1,17 @@
+workspace/
+venv/
+__pycache__/
+*.pyc
+.git/
+.env
+configs/
+docs/
+tests/
+logs/
+work/
+experiment/
+FBv2-Dashboard/
+*.log
+.coverage
+htmlcov/
+.pytest_cache/

--- a/FuzzingBrain-v2/v2/.env.example
+++ b/FuzzingBrain-v2/v2/.env.example
@@ -1,0 +1,7 @@
+# LLM API Keys (at least one required)
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+
+# Optional: override workspace path (default: $PWD/workspace)
+# FUZZINGBRAIN_HOST_WORKSPACE=/absolute/path/to/workspace

--- a/FuzzingBrain-v2/v2/.gitignore
+++ b/FuzzingBrain-v2/v2/.gitignore
@@ -18,3 +18,7 @@ htmlcov/
 # Eval server runtime
 .eval_pids/
 logs/eval/
+FBv2-Dashboard/
+
+# Environment secrets
+.env

--- a/FuzzingBrain-v2/v2/Dockerfile
+++ b/FuzzingBrain-v2/v2/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git git-lfs curl build-essential openssh-client ca-certificates gnupg \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update && apt-get install -y --no-install-recommends docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /root/.ssh \
+    && ssh-keyscan github.com gitlab.com bitbucket.org >> /root/.ssh/known_hosts 2>/dev/null \
+    && git lfs install
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY fuzzingbrain/ fuzzingbrain/
+
+ENV RUNNING_IN_DOCKER=true
+ENTRYPOINT ["python3", "-m", "fuzzingbrain.main"]

--- a/FuzzingBrain-v2/v2/docker-compose.yml
+++ b/FuzzingBrain-v2/v2/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  fb-mongo:
+    image: mongo:8.0
+    container_name: fb-mongo
+    restart: unless-stopped
+    volumes:
+      - fb-mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  fb-redis:
+    image: redis:7-alpine
+    container_name: fb-redis
+    restart: unless-stopped
+    volumes:
+      - fb-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  fb-task:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${FUZZINGBRAIN_HOST_WORKSPACE:-${PWD}/workspace}:${FUZZINGBRAIN_HOST_WORKSPACE:-${PWD}/workspace}
+      - ${PWD}:${PWD}:ro
+      - ${PWD}/logs:/app/logs
+    environment:
+      MONGODB_URL: "mongodb://fb-mongo:27017"
+      MONGODB_DB: "fuzzingbrain"
+      REDIS_URL: "redis://fb-redis:6379/0"
+      RUNNING_IN_DOCKER: "true"
+      FUZZINGBRAIN_WORKSPACE_BASE: "${FUZZINGBRAIN_HOST_WORKSPACE:-${PWD}/workspace}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY}"
+      GEMINI_API_KEY: "${GEMINI_API_KEY}"
+    depends_on:
+      fb-mongo:
+        condition: service_healthy
+      fb-redis:
+        condition: service_healthy
+    profiles:
+      - task
+
+volumes:
+  fb-mongo-data:
+  fb-redis-data:

--- a/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/models.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/models.py
@@ -5,7 +5,7 @@ Request/Response models for communication between Controller and Analyzer.
 """
 
 from dataclasses import dataclass, field
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 from datetime import datetime
 
 
@@ -26,9 +26,9 @@ class AnalyzeRequest:
     log_dir: Optional[str] = None  # Log directory path
     prebuild_dir: Optional[str] = None  # Path to prebuild data directory
     work_id: Optional[str] = None  # Work ID for prebuild data remapping
-    fuzzer_sources: Dict[str, str] = field(
+    fuzzer_sources: Dict[str, Union[str, List[str]]] = field(
         default_factory=dict
-    )  # fuzzer_name -> source_path
+    )  # fuzzer_name -> source_path or list of source_paths
 
     def to_dict(self) -> dict:
         return {

--- a/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/server.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/server.py
@@ -960,7 +960,9 @@ class AnalysisServer:
         separator = "\n\n" + "=" * 72 + "\n\n"
         return {
             "fuzzer": fuzzer_info.name,
-            "source_path": resolved_paths if len(resolved_paths) > 1 else resolved_paths[0],
+            "source_path": resolved_paths
+            if len(resolved_paths) > 1
+            else resolved_paths[0],
             "source": separator.join(contents),
         }
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/tasks.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/analyzer/tasks.py
@@ -12,7 +12,7 @@ import sys
 import time
 import multiprocessing
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 from loguru import logger
 
@@ -32,7 +32,7 @@ def _run_server_process(
     result_queue: multiprocessing.Queue,
     prebuild_dir: Optional[str] = None,
     work_id: Optional[str] = None,
-    fuzzer_sources: Optional[Dict[str, str]] = None,
+    fuzzer_sources: Optional[Dict[str, Union[str, List[str]]]] = None,
 ):
     """
     Run the Analysis Server in a subprocess.

--- a/FuzzingBrain-v2/v2/fuzzingbrain/core/infrastructure.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/core/infrastructure.py
@@ -54,6 +54,16 @@ class RedisManager:
             logger.info(f"Redis already running at {self.host}:{self.port}")
             return True
 
+        if os.environ.get("RUNNING_IN_DOCKER"):
+            logger.info("Running in Docker, waiting for external Redis...")
+            for _ in range(30):
+                time.sleep(0.5)
+                if self.is_running():
+                    logger.info(f"Redis ready at {self.host}:{self.port}")
+                    return True
+            logger.error("Redis not available after 15s")
+            return False
+
         logger.info("Redis not running, attempting to start...")
         return self._start_redis()
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/monitor.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/fuzzer/monitor.py
@@ -470,7 +470,11 @@ class FuzzerMonitor:
                 )
                 # Only cache DB results; fallback may race with Worker record creation
                 if from_db:
-                    self._worker_cache[worker_dir_str] = (worker_id, fuzzer_name, sanitizer)
+                    self._worker_cache[worker_dir_str] = (
+                        worker_id,
+                        fuzzer_name,
+                        sanitizer,
+                    )
 
             fuzzer_worker_dir = worker_dir / "fuzzer_worker"
             if not fuzzer_worker_dir.exists():

--- a/FuzzingBrain-v2/v2/fuzzingbrain/llms/client.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/llms/client.py
@@ -292,13 +292,19 @@ class LLMClient:
 
         if cls._current_loop_id is not None and cls._current_loop_id != current_loop_id:
             # Event loop changed! Clear litellm's cached clients
-            if hasattr(litellm, "in_memory_llm_clients_cache"):
-                cache = litellm.in_memory_llm_clients_cache
-                if cache:
-                    cache.clear()
-                    logger.debug(
-                        "Cleared litellm client cache due to event loop change"
-                    )
+            try:
+                if hasattr(litellm, "in_memory_llm_clients_cache"):
+                    cache = litellm.in_memory_llm_clients_cache
+                    if cache:
+                        if hasattr(cache, "clear"):
+                            cache.clear()
+                        elif hasattr(cache, "cache"):
+                            cache.cache.clear()
+                        logger.debug(
+                            "Cleared litellm client cache due to event loop change"
+                        )
+            except Exception:
+                pass  # Best-effort: never block LLM calls
 
         cls._current_loop_id = current_loop_id
 

--- a/FuzzingBrain-v2/v2/fuzzingbrain/main.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/main.py
@@ -764,7 +764,9 @@ def setup_workspace(config: Config) -> Config:
     import tempfile
 
     script_dir = Path(__file__).parent.parent
-    workspace_base = script_dir / "workspace"
+    workspace_base = Path(
+        os.environ.get("FUZZINGBRAIN_WORKSPACE_BASE", str(script_dir / "workspace"))
+    )
 
     # Generate task ID if not provided
     task_id = config.task_id or str(ObjectId())

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/mcp_factory.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/mcp_factory.py
@@ -525,7 +525,9 @@ def _register_code_viewer_tools(mcp: FastMCP) -> None:
         actual_pattern = pattern or query
         if not actual_pattern:
             return {"error": "pattern or query is required", "matches": [], "count": 0}
-        return search_code_impl(actual_pattern, file_pattern, max_results, context_lines)
+        return search_code_impl(
+            actual_pattern, file_pattern, max_results, context_lines
+        )
 
     @mcp.tool
     @async_tool

--- a/FuzzingBrain-v2/v2/fuzzingbrain/tools/mcp_factory.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/tools/mcp_factory.py
@@ -506,7 +506,8 @@ def _register_code_viewer_tools(mcp: FastMCP) -> None:
     @mcp.tool
     @async_tool
     def search_code(
-        pattern: str,
+        pattern: str = None,
+        query: str = None,
         file_pattern: str = None,
         max_results: int = 50,
         context_lines: int = 2,
@@ -516,11 +517,15 @@ def _register_code_viewer_tools(mcp: FastMCP) -> None:
 
         Args:
             pattern: Search pattern (supports regex)
+            query: Alias for pattern
             file_pattern: Optional glob pattern to filter files
             max_results: Maximum number of matches to return
             context_lines: Number of context lines around matches
         """
-        return search_code_impl(pattern, file_pattern, max_results, context_lines)
+        actual_pattern = pattern or query
+        if not actual_pattern:
+            return {"error": "pattern or query is required", "matches": [], "count": 0}
+        return search_code_impl(actual_pattern, file_pattern, max_results, context_lines)
 
     @mcp.tool
     @async_tool

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/context.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/context.py
@@ -325,11 +325,9 @@ class WorkerContext:
                     "phase_verify": self.phase_verify,
                     "phase_pov": self.phase_pov,
                     "phase_save": self.phase_save,
-                    # LLM usage
-                    "llm_calls": self.llm_calls,
-                    "llm_cost": self.llm_cost,
-                    "llm_input_tokens": self.llm_input_tokens,
-                    "llm_output_tokens": self.llm_output_tokens,
+                    # NOTE: llm_calls/llm_cost/llm_input_tokens/llm_output_tokens
+                    # are managed exclusively by WorkerLLMBuffer via $inc.
+                    # Do NOT $set them here — it would overwrite the buffer's increments.
                     # Result
                     "result_summary": self.result_summary,
                 }

--- a/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_delta.py
+++ b/FuzzingBrain-v2/v2/fuzzingbrain/worker/strategies/pov_delta.py
@@ -379,17 +379,9 @@ class POVDeltaStrategy(POVBaseStrategy):
         analysis_client = self.get_analysis_client()
         if analysis_client:
             try:
-                fuzzer_source = (
-                    analysis_client.get_file_content(f"{self.fuzzer}.cc") or ""
-                )
-                if not fuzzer_source:
-                    fuzzer_source = (
-                        analysis_client.get_file_content(f"{self.fuzzer}.cpp") or ""
-                    )
-                if not fuzzer_source:
-                    fuzzer_source = (
-                        analysis_client.get_file_content(f"{self.fuzzer}.c") or ""
-                    )
+                result = analysis_client.get_fuzzer_source(self.fuzzer)
+                if result and isinstance(result, dict):
+                    fuzzer_source = result.get("source", "")
             except Exception as e:
                 self.log_warning(f"Failed to get fuzzer source: {e}")
 

--- a/FuzzingBrain-v2/v2/run-docker.sh
+++ b/FuzzingBrain-v2/v2/run-docker.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# FuzzingBrain Docker runner
+# Usage: ./run-docker.sh <config.json> [extra args...]
+
+set -e
+
+# Colors
+CLAUDE_ORANGE='\033[38;5;208m'
+CLAUDE_BROWN='\033[38;5;172m'
+CLAUDE_SAND='\033[38;5;180m'
+WHITE='\033[1;37m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+echo -e "${CLAUDE_ORANGE}"
+cat << 'EOF'
+    ███████╗██╗   ██╗███████╗███████╗██╗███╗   ██╗ ██████╗
+    ██╔════╝██║   ██║╚══███╔╝╚══███╔╝██║████╗  ██║██╔════╝
+    █████╗  ██║   ██║  ███╔╝   ███╔╝ ██║██╔██╗ ██║██║  ███╗
+    ██╔══╝  ██║   ██║ ███╔╝   ███╔╝  ██║██║╚██╗██║██║   ██║
+    ██║     ╚██████╔╝███████╗███████╗██║██║ ╚████║╚██████╔╝
+    ╚═╝      ╚═════╝ ╚══════╝╚══════╝╚═╝╚═╝  ╚═══╝ ╚═════╝
+EOF
+echo -e "${CLAUDE_BROWN}"
+cat << 'EOF'
+    ██████╗ ██████╗  █████╗ ██╗███╗   ██╗
+    ██╔══██╗██╔══██╗██╔══██╗██║████╗  ██║
+    ██████╔╝██████╔╝███████║██║██╔██╗ ██║
+    ██╔══██╗██╔══██╗██╔══██║██║██║╚██╗██║
+    ██████╔╝██║  ██║██║  ██║██║██║ ╚████║
+    ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝
+EOF
+echo -e "${NC}"
+echo -e "${CLAUDE_SAND}    ══════════════════════════════════════════════════════════════${NC}"
+echo -e "${CLAUDE_ORANGE}              Autonomous Cyber Reasoning System v2.0 (Docker)${NC}"
+echo -e "${CLAUDE_SAND}    ══════════════════════════════════════════════════════════════${NC}"
+echo ""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <config.json> [extra args...]"
+    exit 1
+fi
+
+# Resolve config path before cd (so relative paths work from any directory)
+CONFIG_PATH=$(realpath "$1")
+CONFIG_DIR=$(dirname "$CONFIG_PATH")
+shift
+
+cd "$SCRIPT_DIR"
+
+# Check .env file
+if [ ! -f .env ]; then
+    echo "[ERROR] .env file not found. Creating from .env.example..."
+    cp .env.example .env
+    echo "[ERROR] Please edit .env and add your API keys, then re-run."
+    exit 1
+fi
+
+# Auto-build image if not exists
+if ! docker image inspect v2-fb-task >/dev/null 2>&1; then
+    echo "[INFO] Building fb-task image (first run)..."
+    docker compose build fb-task
+fi
+
+# Start MongoDB and Redis via compose
+echo "[INFO] Starting infrastructure (MongoDB + Redis)..."
+if ! docker compose up -d fb-mongo fb-redis 2>/dev/null; then
+    # Fix Docker 28 + nftables compatibility: create missing isolation chains
+    echo "[WARN] Docker network creation failed, attempting nftables fix..."
+    if command -v nft &>/dev/null; then
+        sudo nft add chain ip filter DOCKER-ISOLATION-STAGE-1 2>/dev/null || true
+        sudo nft add chain ip filter DOCKER-ISOLATION-STAGE-2 2>/dev/null || true
+    else
+        sudo iptables -t filter -N DOCKER-ISOLATION-STAGE-1 2>/dev/null || true
+        sudo iptables -t filter -N DOCKER-ISOLATION-STAGE-2 2>/dev/null || true
+    fi
+    docker compose up -d fb-mongo fb-redis
+fi
+
+# Build extra args
+EXTRA_ARGS=()
+
+# SSH: prefer agent forwarding (safer), fallback to key mount
+if [ -n "$SSH_AUTH_SOCK" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+    echo "[INFO] SSH agent detected, forwarding into container"
+    EXTRA_ARGS+=(-v "$SSH_AUTH_SOCK:/ssh-agent:ro" -e "SSH_AUTH_SOCK=/ssh-agent")
+elif [ -d ~/.ssh ]; then
+    echo "[INFO] Mounting ~/.ssh into container (read-only)"
+    EXTRA_ARGS+=(-v "$HOME/.ssh:/root/.ssh:ro")
+fi
+
+# Run task
+docker compose run --rm --no-deps \
+    -v "$CONFIG_DIR:$CONFIG_DIR:ro" \
+    "${EXTRA_ARGS[@]}" \
+    fb-task --config "$CONFIG_PATH" "$@"
+
+# Fix workspace file ownership (container runs as root)
+WORKSPACE_DIR="${FUZZINGBRAIN_HOST_WORKSPACE:-$SCRIPT_DIR/workspace}"
+if [ -d "$WORKSPACE_DIR" ]; then
+    sudo chown -R "$(id -u):$(id -g)" "$WORKSPACE_DIR" 2>/dev/null || true
+fi


### PR DESCRIPTION
## Summary
- One-command Docker deployment: `./FuzzingBrain.sh --docker work/task.json`
- Symmetric mount pattern (container paths = host paths) for DooD compatibility
- Bridge networking with auto nft/iptables fix for Docker 28 + nftables
- Bug fixes: worker_id race condition, litellm LLMClientCache compat, delta fuzzer source API

## Changes
**Docker deployment (9 files)**
- `Dockerfile`: python:3.12-slim + docker-ce-cli + git-lfs + openssh
- `docker-compose.yml`: fb-mongo, fb-redis, fb-task with symmetric workspace mount
- `run-docker.sh`: standalone Docker runner
- `FuzzingBrain.sh`: `--docker` and `--rebuild` flags, all 6 execution paths
- `main.py`: `FUZZINGBRAIN_WORKSPACE_BASE` env var support
- `infrastructure.py`: Docker-mode Redis wait logic
- `.env.example`, `.dockerignore`, `.gitignore`

**Bug fixes (4 files)**
- `monitor.py`: don't cache fallback worker_id (race with Worker DB creation)
- `dispatcher.py`: fallback workspace_path query for POV count update
- `client.py`: litellm `LLMClientCache` compat (no `.clear()` in new versions)
- `pov_delta.py`: `get_file_content()` → `get_fuzzer_source()` (correct API)

## Test plan
- [x] `./FuzzingBrain.sh --docker work/lp-full-01.json` — libpng full scan end-to-end
- [x] POV found and packaged successfully in Docker mode
- [x] Bridge networking with nft auto-fix verified on Azure Linux
- [ ] Test on macOS with Docker Desktop
- [ ] Test `--rebuild` flag after code changes