### PR TITLE
chore: license compliance — SPDX headers + clarify strip_license_text intent

### DIFF
--- a/FuzzingBrain.sh
+++ b/FuzzingBrain.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CRS_DIR="$SCRIPT_DIR/crs"

--- a/aks-cluster-deploy/crs-architecture.sh
+++ b/aks-cluster-deploy/crs-architecture.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -e
 
 ##set ANSI escaape codes

--- a/api_key_validator/LLM_validator.py
+++ b/api_key_validator/LLM_validator.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 LLM API Key Validator
 Supports validation of API keys for multiple large language models

--- a/competition-api/cmd/server/main.go
+++ b/competition-api/cmd/server/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/competition-api/cmd/test/send_task.go
+++ b/competition-api/cmd/test/send_task.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/competition-api/cmd/test/send_vuln.go
+++ b/competition-api/cmd/test/send_vuln.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/competition-api/internal/handlers/handlers.go
+++ b/competition-api/internal/handlers/handlers.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package handlers
 
 import (

--- a/competition-api/internal/models/types.go
+++ b/competition-api/internal/models/types.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package models
 
 import "encoding/json"

--- a/competition-api/internal/telemetry/telemetry.go
+++ b/competition-api/internal/telemetry/telemetry.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package telemetry
 
 import (

--- a/competition-api/internal/testmodels/types.go
+++ b/competition-api/internal/testmodels/types.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package testmodels
 
 import (

--- a/competition-api/update_image.sh
+++ b/competition-api/update_image.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 docker build -f Dockerfile.sub -t crs-sub:latest .
 docker tag crs-sub:latest ghcr.io/parasol-aser/crs-sub:latest
 docker push ghcr.io/parasol-aser/crs-sub:latest

--- a/crs/build-local-crs-image.sh
+++ b/crs/build-local-crs-image.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Get the Git reference and save it to VERSION file
 git_ref=$(git describe --tags --exact-match HEAD 2>/dev/null || git rev-parse --short HEAD)
 echo "$git_ref" > ./VERSION

--- a/crs/build_task.py
+++ b/crs/build_task.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 This script is used to build a task for the CRS.
 

--- a/crs/cmd/local/main.go
+++ b/crs/cmd/local/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/crs/cmd/server/main.go
+++ b/crs/cmd/server/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/crs/cmd/worker/main.go
+++ b/crs/cmd/worker/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/crs/entrypoint.sh
+++ b/crs/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 set -eu
 
 # ---------- Start Docker daemon (needed by some tasks) ----------

--- a/crs/eval_qx.sh
+++ b/crs/eval_qx.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 # --- option parsing ----------------------------------------------------------

--- a/crs/internal/competition/client.go
+++ b/crs/internal/competition/client.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package competition
 
 import (

--- a/crs/internal/competition/client_test.go
+++ b/crs/internal/competition/client_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package competition
 
 import (

--- a/crs/internal/config/config.go
+++ b/crs/internal/config/config.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package config
 
 import (

--- a/crs/internal/config/config_test.go
+++ b/crs/internal/config/config_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package config
 
 import (

--- a/crs/internal/database/models.go
+++ b/crs/internal/database/models.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package database
 
 import (

--- a/crs/internal/database/reachable_function.go
+++ b/crs/internal/database/reachable_function.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package database
 
 // ReachableFunction represents a function that can be reached from the fuzzer entry point

--- a/crs/internal/executor/doc.go
+++ b/crs/internal/executor/doc.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // Package executor provides fuzzing task execution and distribution capabilities
 // for the CRS (Coverage-guided Fuzzing as a Service) system.
 //

--- a/crs/internal/executor/errors.go
+++ b/crs/internal/executor/errors.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import "errors"

--- a/crs/internal/executor/full_scan_strategies.go
+++ b/crs/internal/executor/full_scan_strategies.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/executor/patch_strategies.go
+++ b/crs/internal/executor/patch_strategies.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/executor/pov_management.go
+++ b/crs/internal/executor/pov_management.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/executor/pov_management_test.go
+++ b/crs/internal/executor/pov_management_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/executor/pov_strategies.go
+++ b/crs/internal/executor/pov_strategies.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/executor/security_analyzer.go
+++ b/crs/internal/executor/security_analyzer.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/executor/task_distribution.go
+++ b/crs/internal/executor/task_distribution.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/executor/task_distribution_test.go
+++ b/crs/internal/executor/task_distribution_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/executor/task_execution.go
+++ b/crs/internal/executor/task_execution.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package executor
 
 import (

--- a/crs/internal/handlers/handlers.go
+++ b/crs/internal/handlers/handlers.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package handlers
 
 import (

--- a/crs/internal/handlers/handlers_test.go
+++ b/crs/internal/handlers/handlers_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package handlers
 
 import (

--- a/crs/internal/handlers/handlers_unit_test.go
+++ b/crs/internal/handlers/handlers_unit_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package handlers
 
 import (

--- a/crs/internal/models/models.go
+++ b/crs/internal/models/models.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package models
 
 import (

--- a/crs/internal/services/common.go
+++ b/crs/internal/services/common.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/services/common_test.go
+++ b/crs/internal/services/common_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/services/local_service.go
+++ b/crs/internal/services/local_service.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/services/local_service_test.go
+++ b/crs/internal/services/local_service_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/services/local_service_unit_test.go
+++ b/crs/internal/services/local_service_unit_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/services/web_service.go
+++ b/crs/internal/services/web_service.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/services/web_service_test.go
+++ b/crs/internal/services/web_service_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/services/worker_service.go
+++ b/crs/internal/services/worker_service.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/services/worker_service_test.go
+++ b/crs/internal/services/worker_service_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package services
 
 import (

--- a/crs/internal/telemetry/telemetry.go
+++ b/crs/internal/telemetry/telemetry.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package telemetry
 
 import (

--- a/crs/internal/telemetry/telemetry_test.go
+++ b/crs/internal/telemetry/telemetry_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package telemetry
 
 import (

--- a/crs/internal/utils/build/builder.go
+++ b/crs/internal/utils/build/builder.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package build
 
 import (

--- a/crs/internal/utils/environment/setup.go
+++ b/crs/internal/utils/environment/setup.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package environment
 
 import (

--- a/crs/internal/utils/environment/setup_test.go
+++ b/crs/internal/utils/environment/setup_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package environment
 
 import (

--- a/crs/internal/utils/fuzzer/discovery.go
+++ b/crs/internal/utils/fuzzer/discovery.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package fuzzer
 
 import (

--- a/crs/internal/utils/fuzzer/discovery_test.go
+++ b/crs/internal/utils/fuzzer/discovery_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package fuzzer
 
 import (

--- a/crs/internal/utils/helpers/common.go
+++ b/crs/internal/utils/helpers/common.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package helpers
 
 import (

--- a/crs/internal/utils/helpers/common_test.go
+++ b/crs/internal/utils/helpers/common_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package helpers
 
 import (

--- a/crs/internal/utils/libfuzzer/analyzer.go
+++ b/crs/internal/utils/libfuzzer/analyzer.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package libfuzzer
 
 import (

--- a/crs/internal/utils/libfuzzer/analyzer_test.go
+++ b/crs/internal/utils/libfuzzer/analyzer_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package libfuzzer
 
 import (

--- a/crs/local_deployment.sh
+++ b/crs/local_deployment.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 # Load environment variables from .env file
 if [ -f ./.env ]; then

--- a/crs/recorder.py
+++ b/crs/recorder.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Send http request to the server to render the task and save the result.
 """

--- a/crs/run_crs.sh
+++ b/crs/run_crs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 DATE=$(date +"%Y%m%d_%H%M%S")
 IN_PLACE=false

--- a/crs/run_crs_batch.py
+++ b/crs/run_crs_batch.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 This script will run CRS on a project with a given number of tasks (a batch).
 

--- a/crs/send_strategies.sh
+++ b/crs/send_strategies.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 # Copy everything from ./strategy to /app/strategy

--- a/crs/strategy/analysis/__init__.py
+++ b/crs/strategy/analysis/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/crs/strategy/code_analysis/__init__.py
+++ b/crs/strategy/code_analysis/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Code Analysis Package
 

--- a/crs/strategy/code_analysis/coverage_analyzer.py
+++ b/crs/strategy/code_analysis/coverage_analyzer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Code Coverage Analyzer
 

--- a/crs/strategy/common/__init__.py
+++ b/crs/strategy/common/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Common utilities and shared components for CRS strategies"""

--- a/crs/strategy/common/analysis_client/__init__.py
+++ b/crs/strategy/common/analysis_client/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Static analysis service client, local runner, CPG helpers, and full-scan helpers."""
 from .client import (
     extract_call_paths_from_analysis_service,

--- a/crs/strategy/common/analysis_client/client.py
+++ b/crs/strategy/common/analysis_client/client.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Static analysis integration.
 
 Entry points for the external analysis service, the local CodeQL /

--- a/crs/strategy/common/analysis_client/full_scan.py
+++ b/crs/strategy/common/analysis_client/full_scan.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Full-scan analysis helpers.
 
 Full-scan POV strategies enumerate every function reachable from the

--- a/crs/strategy/common/code/__init__.py
+++ b/crs/strategy/common/code/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Source code extraction, replacement, metadata, cleanup, and sandbox execution."""
 from .cleanup import strip_comments_and_license, strip_license_text
 from .extract import extract_function_body, extract_function_name_from_code, extract_java_method

--- a/crs/strategy/common/code/cleanup.py
+++ b/crs/strategy/common/code/cleanup.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Source-code cleanup helpers (license/comment stripping)."""
 from __future__ import annotations
 

--- a/crs/strategy/common/code/cleanup.py
+++ b/crs/strategy/common/code/cleanup.py
@@ -33,6 +33,13 @@ _LICENSE_KEYWORDS: Tuple[str, ...] = (
 def strip_license_text(source_code: str) -> str:
     """Remove a leading copyright / license block from ``source_code``.
 
+    This is an in-memory preprocessing step used solely to reduce the token
+    count of prompts sent to a Large Language Model (LLM) for vulnerability
+    analysis and patch generation. The returned string is consumed by the
+    LLM client only; it is **never written back to disk, committed, or
+    redistributed**, and no third-party source code is published with its
+    license / copyright information removed.
+
     First tries a structured block scan (``/* ... */`` style) anchored on
     license keywords; if that does not find a clear block, falls back to
     a heuristic that drops any leading run of comment lines whose combined

--- a/crs/strategy/common/code/extract.py
+++ b/crs/strategy/common/code/extract.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Source-code inspection utilities.
 
 Helpers that read source files or source snippets to extract function

--- a/crs/strategy/common/code/fundef.py
+++ b/crs/strategy/common/code/fundef.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Wrapper around the ``fundef`` binary.
 
 ``fundef`` is a small Go helper shipped alongside the strategy worker

--- a/crs/strategy/common/code/java.py
+++ b/crs/strategy/common/code/java.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Java-specific helpers (jar selection, etc.)."""
 from __future__ import annotations
 

--- a/crs/strategy/common/code/paths.py
+++ b/crs/strategy/common/code/paths.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Path fix-ups for source files inside a patched workspace.
 
 When the patch pipeline copies a project source tree into a sibling

--- a/crs/strategy/common/code/sandbox.py
+++ b/crs/strategy/common/code/sandbox.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Run LLM-generated Python snippets.
 
 The CRS asks the LLM to emit a Python script that writes a reproducing

--- a/crs/strategy/common/code/similarity.py
+++ b/crs/strategy/common/code/similarity.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Structural similarity metrics for source snippets.
 
 Used when an LLM proposes a patched function and we need to sanity-check

--- a/crs/strategy/common/config.py
+++ b/crs/strategy/common/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Strategy Configuration
 Replaces global variables with a clean config object

--- a/crs/strategy/common/crash/__init__.py
+++ b/crs/strategy/common/crash/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Crash parsing, location extraction, reproduction, and signatures."""
 from .extract import extract_and_save_crash_input
 from .location import (

--- a/crs/strategy/common/crash/extract.py
+++ b/crs/strategy/common/crash/extract.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Crash input extraction and verification.
 
 Given a directory of candidate crash files produced by a fuzzer, walks them

--- a/crs/strategy/common/crash/location.py
+++ b/crs/strategy/common/crash/location.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Crash location extraction and vulnerability signature hashing.
 
 Given raw fuzzer/sanitiser output, produce a concise ``file:line`` style

--- a/crs/strategy/common/crash/output.py
+++ b/crs/strategy/common/crash/output.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Crash-section extraction from fuzzer transcripts.
 
 Given the combined stdout/stderr of a libFuzzer run, pull out the most

--- a/crs/strategy/common/diff/__init__.py
+++ b/crs/strategy/common/diff/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Diff and commit processing."""
 from .commit import get_commit_info, parse_commit_diff
 from .funtarget import extract_diff_functions_using_funtarget

--- a/crs/strategy/common/diff/commit.py
+++ b/crs/strategy/common/diff/commit.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Commit diff loading and per-function extraction.
 
 Two entry points:

--- a/crs/strategy/common/diff/funtarget.py
+++ b/crs/strategy/common/diff/funtarget.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Wrapper around the ``funtarget`` binary for diff-function extraction.
 
 ``funtarget`` is a small Go/C helper shipped alongside the strategy

--- a/crs/strategy/common/diff/process.py
+++ b/crs/strategy/common/diff/process.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Large-diff processor.
 
 When a commit diff is huge (>50 KB is typical), LLM context budgets

--- a/crs/strategy/common/fuzzing/__init__.py
+++ b/crs/strategy/common/fuzzing/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Fuzzer execution, image resolution, discovery, output, and lifecycle.
 
 Note: ``runner`` is intentionally not re-exported at the package level

--- a/crs/strategy/common/fuzzing/discovery.py
+++ b/crs/strategy/common/fuzzing/discovery.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Fuzzer source-file discovery.
 
 Given a fuzzer binary produced by an OSS-Fuzz build, figure out which

--- a/crs/strategy/common/fuzzing/docker_lifecycle.py
+++ b/crs/strategy/common/fuzzing/docker_lifecycle.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Process-scoped docker container cleanup.
 
 Registers an ``atexit`` hook plus ``SIGINT``/``SIGTERM`` handlers that stop

--- a/crs/strategy/common/fuzzing/image.py
+++ b/crs/strategy/common/fuzzing/image.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Docker image resolution for OSS-Fuzz / AIXCC project containers."""
 from __future__ import annotations
 

--- a/crs/strategy/common/fuzzing/output.py
+++ b/crs/strategy/common/fuzzing/output.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Fuzzer output post-processing (log filtering, line truncation).
 
 Helpers that operate on captured fuzzer stdout/stderr before it is logged

--- a/crs/strategy/common/fuzzing/runner.py
+++ b/crs/strategy/common/fuzzing/runner.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """libFuzzer execution with streaming output, coverage parsing, and crash detection.
 
 This module runs a fuzzer binary inside the project's OSS-Fuzz docker image,

--- a/crs/strategy/common/llm/__init__.py
+++ b/crs/strategy/common/llm/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LLM client, models, and response parsing."""
 from .response import (
     extract_code,

--- a/crs/strategy/common/llm/client.py
+++ b/crs/strategy/common/llm/client.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 LLM Client
 Unified interface for all LLM API calls

--- a/crs/strategy/common/llm/models.py
+++ b/crs/strategy/common/llm/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Model constants and fallback logic
 """

--- a/crs/strategy/common/llm/response.py
+++ b/crs/strategy/common/llm/response.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Parsing helpers for LLM response text.
 
 Extracts code blocks from markdown-formatted LLM output, heuristically

--- a/crs/strategy/common/logging/__init__.py
+++ b/crs/strategy/common/logging/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Logging utilities for strategies"""

--- a/crs/strategy/common/logging/logger.py
+++ b/crs/strategy/common/logging/logger.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Strategy Logger
 Unified logging for all strategies using loguru

--- a/crs/strategy/common/ossfuzz_generator/__init__.py
+++ b/crs/strategy/common/ossfuzz_generator/__init__.py
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 # OSS-Fuzz Integration Generator using Claude Agent SDK
 from .agent import generate_ossfuzz_integration, fix_build_error

--- a/crs/strategy/common/ossfuzz_generator/agent.py
+++ b/crs/strategy/common/ossfuzz_generator/agent.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 OSS-Fuzz Integration Generator using Claude Agent SDK
 

--- a/crs/strategy/common/patch/__init__.py
+++ b/crs/strategy/common/patch/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Patch application, generation, metadata, validation, and workspace management."""
 from .apply import apply_patch, replace_function
 from .generate import INITIAL_PATCH_TEMPLATE, generate_patch

--- a/crs/strategy/common/patch/apply.py
+++ b/crs/strategy/common/patch/apply.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Apply LLM-generated patches to a project source tree.
 
 Two entry points:

--- a/crs/strategy/common/patch/generate.py
+++ b/crs/strategy/common/patch/generate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LLM-driven patch generation."""
 from __future__ import annotations
 

--- a/crs/strategy/common/patch/metadata.py
+++ b/crs/strategy/common/patch/metadata.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Target-function metadata resolution for patch strategies.
 
 Three entry points, in priority order:

--- a/crs/strategy/common/patch/validate.py
+++ b/crs/strategy/common/patch/validate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Patch validation helpers.
 
 Two entry points:

--- a/crs/strategy/common/patch/workspace.py
+++ b/crs/strategy/common/patch/workspace.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Patch workspace helpers (git init, reset, diff)."""
 from __future__ import annotations
 

--- a/crs/strategy/common/pov/__init__.py
+++ b/crs/strategy/common/pov/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """POV storage, submission, lifecycle, and LLM-driven generation."""
 from .cleanup import cleanup_seed_corpus
 from .generate import generate_pov

--- a/crs/strategy/common/pov/cleanup.py
+++ b/crs/strategy/common/pov/cleanup.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """POV seed-corpus cleanup utilities."""
 from __future__ import annotations
 

--- a/crs/strategy/common/pov/generate.py
+++ b/crs/strategy/common/pov/generate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LLM-driven POV generator.
 
 Wraps a single "ask the LLM for Python code that crashes the fuzzer"

--- a/crs/strategy/common/pov/lifecycle.py
+++ b/crs/strategy/common/pov/lifecycle.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Post-crash artefact persistence.
 
 When a POV generator triggers a crash, strategies want to save the

--- a/crs/strategy/common/pov/store.py
+++ b/crs/strategy/common/pov/store.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """POV metadata on-disk store.
 
 Strategies save a JSON ``pov_metadata_*.json`` alongside a Python

--- a/crs/strategy/common/prompts/__init__.py
+++ b/crs/strategy/common/prompts/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Prompt Generation Module for CRS Strategies
 

--- a/crs/strategy/common/prompts/builder.py
+++ b/crs/strategy/common/prompts/builder.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Prompt Builder Functions
 

--- a/crs/strategy/common/prompts/targets.py
+++ b/crs/strategy/common/prompts/targets.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Target-function identification via LLM.
 
 Wraps :func:`common.prompts.builder.construct_get_target_functions_prompt`,

--- a/crs/strategy/common/prompts/templates.py
+++ b/crs/strategy/common/prompts/templates.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Prompt Templates for CRS Strategies
 

--- a/crs/strategy/common/sanitizers/taintsan_fuzzer_example.py
+++ b/crs/strategy/common/sanitizers/taintsan_fuzzer_example.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 Example: Using TaintSan with Atheris for Security Fuzzing
 

--- a/crs/strategy/common/sanitizers/taintsan_javascript/demo.js
+++ b/crs/strategy/common/sanitizers/taintsan_javascript/demo.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
 /**
  * TaintSan JavaScript Demo
  *

--- a/crs/strategy/common/sanitizers/taintsan_javascript/jazzer_integration.js
+++ b/crs/strategy/common/sanitizers/taintsan_javascript/jazzer_integration.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * TaintSan Integration with Jazzer.js
  *

--- a/crs/strategy/common/sanitizers/taintsan_javascript/taintsan.js
+++ b/crs/strategy/common/sanitizers/taintsan_javascript/taintsan.js
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * TaintSan - Taint Tracking Sanitizer for JavaScript/Node.js
  *

--- a/crs/strategy/common/sanitizers/taintsan_python.py
+++ b/crs/strategy/common/sanitizers/taintsan_python.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 TaintSan - Taint Tracking Sanitizer for Python
 

--- a/crs/strategy/common/security_analyzer/__init__.py
+++ b/crs/strategy/common/security_analyzer/__init__.py
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 # Security Analyzer using Claude Agent SDK
 from .agent import analyze_and_verify_vulnerabilities

--- a/crs/strategy/common/security_analyzer/agent.py
+++ b/crs/strategy/common/security_analyzer/agent.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 Security Analyzer using Claude Agent SDK
 

--- a/crs/strategy/common/task/__init__.py
+++ b/crs/strategy/common/task/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Task metadata and input file loaders."""
 from .loader import load_security_findings, load_suspected_vulns
 

--- a/crs/strategy/common/task/loader.py
+++ b/crs/strategy/common/task/loader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Task-scoped input-file loaders.
 
 Small JSON readers for inputs that ride in the per-task working

--- a/crs/strategy/common/utils/__init__.py
+++ b/crs/strategy/common/utils/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Utility functions for strategies"""
 
 # Text utilities

--- a/crs/strategy/common/utils/code_analysis.py
+++ b/crs/strategy/common/utils/code_analysis.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Code analysis utilities (backward-compatibility shim).
 
 The canonical home is :mod:`common.analysis_client.client`. This module

--- a/crs/strategy/common/utils/code_extract.py
+++ b/crs/strategy/common/utils/code_extract.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Code extraction utilities (backward-compatibility shim).
 
 The canonical homes are:

--- a/crs/strategy/common/utils/crash_utils.py
+++ b/crs/strategy/common/utils/crash_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Crash output parsing utilities (backward-compatibility shim).
 
 All implementations have moved to ``common.crash.location`` and

--- a/crs/strategy/common/utils/fuzzer_utils.py
+++ b/crs/strategy/common/utils/fuzzer_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Fuzzer-related utility functions.
 

--- a/crs/strategy/common/utils/git_utils.py
+++ b/crs/strategy/common/utils/git_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Git and diff processing utilities (backward-compatibility shim).
 

--- a/crs/strategy/common/utils/task_utils.py
+++ b/crs/strategy/common/utils/task_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Task metadata loading.
 
 Historically this module held fuzzer execution, crash extraction, corpus

--- a/crs/strategy/common/utils/text_utils.py
+++ b/crs/strategy/common/utils/text_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Text processing utilities
 """

--- a/crs/strategy/core/__init__.py
+++ b/crs/strategy/core/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Core strategy framework"""

--- a/crs/strategy/core/base_strategy.py
+++ b/crs/strategy/core/base_strategy.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Base Strategy
 Abstract base class for all strategies

--- a/crs/strategy/core/pov_strategy.py
+++ b/crs/strategy/core/pov_strategy.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 PoV Strategy
 Base class for all POV (Proof of Vulnerability) generation strategies

--- a/crs/strategy/legacy_strategy/as0_delta.py
+++ b/crs/strategy/legacy_strategy/as0_delta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/as0_delta.py
+++ b/crs/strategy/legacy_strategy/as0_delta.py
@@ -749,7 +749,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/as0_full.py
+++ b/crs/strategy/legacy_strategy/as0_full.py
@@ -750,7 +750,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/as0_full.py
+++ b/crs/strategy/legacy_strategy/as0_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/c_coverage.py
+++ b/crs/strategy/legacy_strategy/c_coverage.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import argparse
 import re

--- a/crs/strategy/legacy_strategy/compact_branches.py
+++ b/crs/strategy/legacy_strategy/compact_branches.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 compact_branches.py cov.exec classes.jar src_root [--context N] [--no-snippet]
 """

--- a/crs/strategy/legacy_strategy/generate_fuzzer.py
+++ b/crs/strategy/legacy_strategy/generate_fuzzer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 Clone OSS-Fuzz + main repo, apply a patch (diff) that represents the
 ‘target commit’, discover existing fuzzers, and create a brand-new one.

--- a/crs/strategy/legacy_strategy/integration-test/build.sh
+++ b/crs/strategy/legacy_strategy/integration-test/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 
 $CC $CFLAGS $SANITIZER_FLAGS -c $SRC/fuzz_vuln.c -I.
 $CC $CFLAGS $SANITIZER_FLAGS -c $SRC/integration-test/vuln.c -I.

--- a/crs/strategy/legacy_strategy/integration-test/fuzz_vuln.c
+++ b/crs/strategy/legacy_strategy/integration-test/fuzz_vuln.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 #include <stdint.h>
 #include <stddef.h>
 

--- a/crs/strategy/legacy_strategy/integration-test/test.sh
+++ b/crs/strategy/legacy_strategy/integration-test/test.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 
 make test

--- a/crs/strategy/legacy_strategy/java_coverage.py
+++ b/crs/strategy/legacy_strategy/java_coverage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 java_branches.py cov.exec classes.jar src_root [--context N] [--no-snippet]
 """

--- a/crs/strategy/legacy_strategy/joern_query_example.py
+++ b/crs/strategy/legacy_strategy/joern_query_example.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 Example of how to query Joern CPG from Python strategy files.
 

--- a/crs/strategy/legacy_strategy/parse_callgraph.py
+++ b/crs/strategy/legacy_strategy/parse_callgraph.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 
 import re
 import os

--- a/crs/strategy/legacy_strategy/parse_callgraph_full.py
+++ b/crs/strategy/legacy_strategy/parse_callgraph_full.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 Find call‑paths or reachable functions in a CG‑dot file produced by
 clang‑static‑analyzer/llvm‑opt, etc.

--- a/crs/strategy/legacy_strategy/patch0_delta.py
+++ b/crs/strategy/legacy_strategy/patch0_delta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for delta scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch0_delta.py
+++ b/crs/strategy/legacy_strategy/patch0_delta.py
@@ -692,7 +692,14 @@ def get_commit_info(log_file, project_dir, language):
         return "", ""
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch0_full.py
+++ b/crs/strategy/legacy_strategy/patch0_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for full scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch0_full.py
+++ b/crs/strategy/legacy_strategy/patch0_full.py
@@ -455,7 +455,14 @@ def call_llm(log_file, messages, model_name):
         return "", False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch1_delta.py
+++ b/crs/strategy/legacy_strategy/patch1_delta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for delta scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch1_delta.py
+++ b/crs/strategy/legacy_strategy/patch1_delta.py
@@ -691,7 +691,14 @@ def get_commit_info(log_file, project_dir, language):
         return "", ""
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch1_full.py
+++ b/crs/strategy/legacy_strategy/patch1_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for full scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch1_full.py
+++ b/crs/strategy/legacy_strategy/patch1_full.py
@@ -461,7 +461,14 @@ def call_llm(log_file, messages, model_name):
             return "", False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch2_delta.py
+++ b/crs/strategy/legacy_strategy/patch2_delta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for delta scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch2_delta.py
+++ b/crs/strategy/legacy_strategy/patch2_delta.py
@@ -692,7 +692,14 @@ def get_commit_info(log_file, project_dir, language):
         return "", ""
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch2_full.py
+++ b/crs/strategy/legacy_strategy/patch2_full.py
@@ -462,7 +462,14 @@ def call_llm(log_file, messages, model_name):
             return "", False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch2_full.py
+++ b/crs/strategy/legacy_strategy/patch2_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for full scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch3_delta.py
+++ b/crs/strategy/legacy_strategy/patch3_delta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for delta scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch3_delta.py
+++ b/crs/strategy/legacy_strategy/patch3_delta.py
@@ -692,7 +692,14 @@ def get_commit_info(log_file, project_dir, language):
         return "", ""
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch3_full.py
+++ b/crs/strategy/legacy_strategy/patch3_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for full scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch3_full.py
+++ b/crs/strategy/legacy_strategy/patch3_full.py
@@ -461,7 +461,14 @@ def call_llm(log_file, messages, model_name):
             return "", False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch_delta.py
+++ b/crs/strategy/legacy_strategy/patch_delta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for delta scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/patch_delta.py
+++ b/crs/strategy/legacy_strategy/patch_delta.py
@@ -694,7 +694,14 @@ def get_commit_info(log_file, project_dir, language):
         return "", ""
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch_full.py
+++ b/crs/strategy/legacy_strategy/patch_full.py
@@ -463,7 +463,14 @@ def call_llm(log_file, messages, model_name):
             return "", False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/patch_full.py
+++ b/crs/strategy/legacy_strategy/patch_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for full scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/sarif_pov0.py
+++ b/crs/strategy/legacy_strategy/sarif_pov0.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/sarif_pov0.py
+++ b/crs/strategy/legacy_strategy/sarif_pov0.py
@@ -744,7 +744,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xpatch_delta.py
+++ b/crs/strategy/legacy_strategy/xpatch_delta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for delta scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xpatch_delta.py
+++ b/crs/strategy/legacy_strategy/xpatch_delta.py
@@ -689,7 +689,14 @@ def get_commit_info(log_file, project_dir, language):
         return "", ""
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xpatch_full.py
+++ b/crs/strategy/legacy_strategy/xpatch_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for full scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xpatch_full.py
+++ b/crs/strategy/legacy_strategy/xpatch_full.py
@@ -689,7 +689,14 @@ def get_commit_info(log_file, project_dir, language):
         return "", ""
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xpatch_sarif.py
+++ b/crs/strategy/legacy_strategy/xpatch_sarif.py
@@ -460,7 +460,14 @@ def call_llm(log_file, messages, model_name):
             return "", False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xpatch_sarif.py
+++ b/crs/strategy/legacy_strategy/xpatch_sarif.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # patch strategies for delta scan
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xs0_c_full.py
+++ b/crs/strategy/legacy_strategy/xs0_c_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xs0_c_full.py
+++ b/crs/strategy/legacy_strategy/xs0_c_full.py
@@ -913,7 +913,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xs0_delta.py
+++ b/crs/strategy/legacy_strategy/xs0_delta.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xs0_delta.py
+++ b/crs/strategy/legacy_strategy/xs0_delta.py
@@ -931,7 +931,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xs0_java_full.py
+++ b/crs/strategy/legacy_strategy/xs0_java_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xs0_java_full.py
+++ b/crs/strategy/legacy_strategy/xs0_java_full.py
@@ -913,7 +913,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xs1_c_full.py
+++ b/crs/strategy/legacy_strategy/xs1_c_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xs1_c_full.py
+++ b/crs/strategy/legacy_strategy/xs1_c_full.py
@@ -903,7 +903,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xs1_java_full.py
+++ b/crs/strategy/legacy_strategy/xs1_java_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xs1_java_full.py
+++ b/crs/strategy/legacy_strategy/xs1_java_full.py
@@ -902,7 +902,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/legacy_strategy/xs2_java_full.py
+++ b/crs/strategy/legacy_strategy/xs2_java_full.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # strategy 0
 #!/usr/bin/env python3
 """

--- a/crs/strategy/legacy_strategy/xs2_java_full.py
+++ b/crs/strategy/legacy_strategy/xs2_java_full.py
@@ -902,7 +902,14 @@ def is_likely_source_for_fuzzer(file_base, fuzzer_name, base_name):
     return False
 
 def strip_license_text(source_code):
-    """Strip copyright and license text from source code"""
+    """Strip a leading copyright / license block from ``source_code``.
+
+    NOTE: Used only as an in-memory preprocessing step to reduce token count
+    of prompts sent to an LLM for vulnerability analysis. The result is
+    consumed by the LLM client and is never written back to disk, committed,
+    or redistributed; no third-party source is published with its license /
+    copyright information removed.
+    """
     # Common patterns that indicate license blocks
     license_start_patterns = [
         "/*", 

--- a/crs/strategy/strategies/__init__.py
+++ b/crs/strategy/strategies/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Strategy registry.
 
 Every strategy exposed to the outside world is registered here so the

--- a/crs/strategy/strategies/__main__.py
+++ b/crs/strategy/strategies/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Unified CLI entry point for CRS strategies.
 
 Run a registered strategy by name:

--- a/crs/strategy/strategies/as0/__init__.py
+++ b/crs/strategy/strategies/as0/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """as0: Advanced LLM-guided POV strategy (delta + full).
 
 :class:`AS0DeltaStrategy` handles delta-scan tasks (a commit diff is

--- a/crs/strategy/strategies/as0/delta.py
+++ b/crs/strategy/strategies/as0/delta.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 AS0 Delta Strategy - Advanced multi-phase POV generation
 

--- a/crs/strategy/strategies/as0/full.py
+++ b/crs/strategy/strategies/as0/full.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """AS0 Full Strategy - full-scan POV generation.
 
 Inherits the multi-phase POV loop from :class:`AS0DeltaStrategy` but

--- a/crs/strategy/strategies/patch/__init__.py
+++ b/crs/strategy/strategies/patch/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """patch: LLM-guided patch generation strategy (delta + full)."""
 from .strategy import PatchStrategy
 

--- a/crs/strategy/strategies/patch/strategy.py
+++ b/crs/strategy/strategies/patch/strategy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """Patch strategy: LLM-guided vulnerability fix generation.
 
 Loops until a generated patch:

--- a/crs/strategy/tests/__init__.py
+++ b/crs/strategy/tests/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 CRS Strategy Test Suite - Enterprise Grade
 

--- a/crs/strategy/tests/conftest.py
+++ b/crs/strategy/tests/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Pytest Configuration and Shared Fixtures - Enterprise Grade
 

--- a/crs/strategy/tests/fixtures/__init__.py
+++ b/crs/strategy/tests/fixtures/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Test Fixtures - Shared test data and mocks
 

--- a/crs/strategy/tests/integration/__init__.py
+++ b/crs/strategy/tests/integration/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Integration Tests - Test component interactions
 

--- a/crs/strategy/tests/regression/__init__.py
+++ b/crs/strategy/tests/regression/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Regression Tests - Ensure refactored code maintains exact behavior
 

--- a/crs/strategy/tests/unit/__init__.py
+++ b/crs/strategy/tests/unit/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Unit Tests - Fast, isolated tests for individual components
 

--- a/crs/update-image.sh
+++ b/crs/update-image.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Navigate to the CRS directory
 cd ../static-analysis
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../crs/strategy/legacy_strategy/fundef ./cmd/funcdef/

--- a/deploy-docker-images.sh
+++ b/deploy-docker-images.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 cd ./static-analysis/
 
 # Build static analysis binaries

--- a/scripts/generate_ossfuzz_integration.sh
+++ b/scripts/generate_ossfuzz_integration.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 # Shell wrapper to generate OSS-Fuzz integration using Claude Agent SDK
 # Called by FuzzingBrain.sh when no existing OSS-Fuzz project is found
 

--- a/static-analysis/build-local-analysis-image.sh
+++ b/static-analysis/build-local-analysis-image.sh
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 # Build the Docker image
 docker build -f Dockerfile.analysis.local -t analysis-local:latest .

--- a/static-analysis/cmd/all/main.go
+++ b/static-analysis/cmd/all/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/cmd/callpath/main.go
+++ b/static-analysis/cmd/callpath/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/cmd/funcdef/main.go
+++ b/static-analysis/cmd/funcdef/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/cmd/functarget/main.go
+++ b/static-analysis/cmd/functarget/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/cmd/llir/main.go
+++ b/static-analysis/cmd/llir/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // This example program analyses an LLVM IR module to produce a callgraph in
 // Graphviz DOT format.
 package main

--- a/static-analysis/cmd/local/main.go
+++ b/static-analysis/cmd/local/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/cmd/scan/main.go
+++ b/static-analysis/cmd/scan/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/cmd/scan/main_test.go
+++ b/static-analysis/cmd/scan/main_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/cmd/server/main.go
+++ b/static-analysis/cmd/server/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/entrypoint-local.sh
+++ b/static-analysis/entrypoint-local.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 
 # Start Docker daemon in background
 dockerd --log-level error > /var/log/docker.log 2>&1 &

--- a/static-analysis/entrypoint.sh
+++ b/static-analysis/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 
 # Start Docker daemon in background
 dockerd --log-level error > /var/log/docker.log 2>&1 &

--- a/static-analysis/integration-test/build.sh
+++ b/static-analysis/integration-test/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 
 $CC $CFLAGS $SANITIZER_FLAGS -c $SRC/fuzz_vuln.c -I.
 $CC $CFLAGS $SANITIZER_FLAGS -c $SRC/integration-test/vuln.c -I.

--- a/static-analysis/integration-test/fuzz_vuln.c
+++ b/static-analysis/integration-test/fuzz_vuln.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 #include <stdint.h>
 #include <stddef.h>
 

--- a/static-analysis/integration-test/test.sh
+++ b/static-analysis/integration-test/test.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 
 make test

--- a/static-analysis/internal/analysis/callgraph/callgraph.go
+++ b/static-analysis/internal/analysis/callgraph/callgraph.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package callgraph
 
 // Function represents a function in the call graph

--- a/static-analysis/internal/analysis/callgraph/dot.go
+++ b/static-analysis/internal/analysis/callgraph/dot.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package callgraph
 
 import (

--- a/static-analysis/internal/analysis/callgraph/merge.go
+++ b/static-analysis/internal/analysis/callgraph/merge.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package callgraph
 
 // Fix unused variable warning

--- a/static-analysis/internal/analysis/visitor/c_visitor.go
+++ b/static-analysis/internal/analysis/visitor/c_visitor.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package visitor
 
 import (

--- a/static-analysis/internal/analysis/visitor/java_visitor.go
+++ b/static-analysis/internal/analysis/visitor/java_visitor.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package visitor
 
 import (

--- a/static-analysis/internal/analyzer/main.go
+++ b/static-analysis/internal/analyzer/main.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/static-analysis/internal/engine/engine.go
+++ b/static-analysis/internal/engine/engine.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package engine
 
 import (

--- a/static-analysis/internal/engine/models/models.go
+++ b/static-analysis/internal/engine/models/models.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package models
 
 import (

--- a/static-analysis/internal/joern/joern.go
+++ b/static-analysis/internal/joern/joern.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package joern
 
 import (

--- a/static-analysis/internal/parser/c/parser.go
+++ b/static-analysis/internal/parser/c/parser.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package c
 
 import (

--- a/static-analysis/internal/parser/c/preprocess.go
+++ b/static-analysis/internal/parser/c/preprocess.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package c
 
 import (

--- a/static-analysis/internal/parser/java/parser.go
+++ b/static-analysis/internal/parser/java/parser.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package java
 
 import (

--- a/static-analysis/internal/simple/simple.go
+++ b/static-analysis/internal/simple/simple.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package simple
 
 import (

--- a/static-analysis/parse_callgraph.py
+++ b/static-analysis/parse_callgraph.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 
 import re
 import os

--- a/static-analysis/parse_callgraph_full.py
+++ b/static-analysis/parse_callgraph_full.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 Find call‑paths or reachable functions in a CG‑dot file produced by
 clang‑static‑analyzer/llvm‑opt, etc.

--- a/static-analysis/update_image.sh
+++ b/static-analysis/update_image.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 docker build -f Dockerfile.analysis -t crs-analysis:latest .
 docker tag crs-analysis:latest ghcr.io/parasol-aser/crs-analysis:latest
 docker push ghcr.io/parasol-aser/crs-analysis:latest

--- a/task_builder/build_task.py
+++ b/task_builder/build_task.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 This script is used to build a task for the CRS.
 

--- a/task_builder/build_task_json.py
+++ b/task_builder/build_task_json.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 # -*- coding: utf-8 -*-
 """
 GitHub Adjacent Commits Generator

--- a/task_builder/test_build_task.py
+++ b/task_builder/test_build_task.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 """
 Test script for build_task.py
 


### PR DESCRIPTION
## Summary

Response to the OpenSSF / Linux Foundation license intake scan feedback. Two commits:

- **`7850cc14`** Update docstrings of `strip_license_text` (canonical definition in `crs/strategy/common/code/cleanup.py` + 22 legacy_strategy copies) to make explicit that license-stripping is an in-memory LLM-prompt preprocessing step and that no third-party source is published with copyright/license info removed.
- **`804f6666`** Add `SPDX-License-Identifier: Apache-2.0` headers to all 219 first-party source files (`.py` / `.go` / `.sh` / `.js` / `.c`). Auto-generated ANTLR parsers in `static-analysis/internal/parser/{c,java}/grammar/` and the third-party BSD-licensed `.g4` grammars are intentionally skipped.

## Verification

- [x] 219/219 in-scope source files have exactly one SPDX header (cross-checked against `git ls-files`)
- [x] All 121 Python files pass `ast.parse`
- [x] Go build status unchanged — pre-existing errors on `stable` are unrelated (line numbers shift by exactly 1, confirming SPDX is the only diff)
- [x] Shell scripts pass `bash -n`
- [x] 8 ANTLR-generated files and 4 BSD-licensed `.g4` grammars confirmed untouched
- [x] No duplicate SPDX headers introduced

## Test plan

- [ ] Confirm CI passes
- [ ] Sanity-check a few sample files for correct comment-syntax/shebang preservation