### PR TITLE
fix: start MongoDB on kernels >= 6.19 and stop treating a crash loop as healthy

### DIFF
--- a/FuzzingBrain.sh
+++ b/FuzzingBrain.sh
@@ -212,6 +212,13 @@ is_in_docker() {
     return 1
 }
 
+container_running() {
+    # True only if the container is actually up.
+    # `docker ps` also lists containers in the "restarting" state, so a
+    # crash-looping container would otherwise read as healthy.
+    [ "$(docker inspect -f '{{.State.Status}}' "$1" 2>/dev/null)" = "running" ]
+}
+
 check_mongodb() {
     # Check if MongoDB is accessible
     # Try multiple methods for compatibility
@@ -232,7 +239,7 @@ check_mongodb() {
 
     # Method 3: Check if container is running (only for local mode)
     if [ "$MONGODB_HOST" = "localhost" ] || [ "$MONGODB_HOST" = "127.0.0.1" ]; then
-        if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${MONGODB_CONTAINER}$"; then
+        if container_running "$MONGODB_CONTAINER"; then
             print_info "MongoDB container is running"
             return 0
         fi
@@ -245,7 +252,7 @@ start_mongodb() {
     # Check if MongoDB container already exists
     if docker ps -a --format '{{.Names}}' | grep -q "^${MONGODB_CONTAINER}$"; then
         # Container exists, check if running
-        if docker ps --format '{{.Names}}' | grep -q "^${MONGODB_CONTAINER}$"; then
+        if container_running "$MONGODB_CONTAINER"; then
             print_info "MongoDB container already running"
             return 0
         else
@@ -265,7 +272,7 @@ start_mongodb() {
             --restart=always \
             -p 0.0.0.0:${MONGODB_PORT}:27017 \
             -v fuzzingbrain-mongodb-data:/data/db \
-            mongo:8.0 > /dev/null
+            mongo:8.2 > /dev/null
 
         # Wait for MongoDB to start
         print_info "Waiting for MongoDB to start..."
@@ -341,7 +348,7 @@ check_redis() {
 
     # Method 3: Check if container is running (only for local mode)
     if [ "$REDIS_HOST" = "localhost" ] || [ "$REDIS_HOST" = "127.0.0.1" ]; then
-        if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${REDIS_CONTAINER}$"; then
+        if container_running "$REDIS_CONTAINER"; then
             print_info "Redis container is running"
             return 0
         fi
@@ -354,7 +361,7 @@ start_redis() {
     # Check if Redis container already exists
     if docker ps -a --format '{{.Names}}' | grep -q "^${REDIS_CONTAINER}$"; then
         # Container exists, check if running
-        if docker ps --format '{{.Names}}' | grep -q "^${REDIS_CONTAINER}$"; then
+        if container_running "$REDIS_CONTAINER"; then
             print_info "Redis container already running"
             return 0
         else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 services:
   fb-mongo:
-    image: mongo:8.0
+    image: mongo:8.2
     container_name: fb-mongo
     restart: unless-stopped
     volumes:

--- a/docs/deployment-plan.md
+++ b/docs/deployment-plan.md
@@ -19,7 +19,7 @@ Host Machine (bare metal / Azure VM)
 │   ├── Eval Server (FastAPI, port 18080)         ← FBv2-Dashboard
 │   └── Eval Dashboard (FastAPI + static, port 18081) ← FBv2-Dashboard
 ├── Docker daemon
-│   ├── mongo:8.0 container        (auto-started, port 27017)
+│   ├── mongo:8.2 container        (auto-started, port 27017)
 │   ├── redis:7-alpine container   (auto-started, port 6379)
 │   └── gcr.io/oss-fuzz/* containers (fuzzer 构建 & 执行)
 └── Local filesystem


### PR DESCRIPTION
mongo:8.0 refuses to boot on Linux 6.19+ (SERVER-121912), so on a current kernel the container crash-looped and nothing ever listened on 27017. Pin mongo:8.2, which starts cleanly and opens an existing 8.0 data directory.

The failure was silent because check_mongodb()/check_redis() fell back to `docker ps | grep <name>`, and `docker ps` also lists containers in the "restarting" state. A crash-looping MongoDB therefore read as healthy and the run proceeded until it actually needed the database. Add a container_running() helper that inspects the real state, and use it in the health checks and in the "already running" branch of both start_* functions.