### PR TITLE
Gate the coverage tools on whether coverage was built

### DIFF
--- a/fuzzingbrain/agents/base.py
+++ b/fuzzingbrain/agents/base.py
@@ -230,25 +230,50 @@ class BaseAgent(ABC):
         then has no way to read code at all, while the run reports success.
         Read, Grep and Glob remain either way.
         """
-        cached = getattr(self, "_static_analysis_available", None)
+        return int(self._analysis_status().get("function_count", 0)) > 0
+
+    @property
+    def include_coverage_tools(self) -> bool:
+        """Whether the coverage tools are worth offering.
+
+        All four read the coverage build output. Offering them when that build
+        produced nothing makes them fail in a way that reads as "this target
+        has no coverage" rather than "coverage was never built" -- the same
+        shape of silent misdirection as an empty function index.
+
+        trace_pov is deliberately not gated with them: it traces with gdb
+        against the ASAN binary and only falls back to coverage, so losing
+        coverage costs it detail rather than breaking it.
+        """
+        return bool(self._analysis_status().get("coverage_available", True))
+
+    def _analysis_status(self) -> dict:
+        """The analysis server's status, fetched once per agent.
+
+        Asked of the server rather than threaded down from the task, because
+        what a run produced is a fact about its data, not about the kind of
+        agent reading it. On failure every capability reads as available, so a
+        server that cannot be reached degrades to today's behaviour rather than
+        silently stripping an agent's tools.
+        """
+        cached = getattr(self, "_analysis_status_cache", None)
         if cached is not None:
             return cached
 
         try:
             from ..analyzer.client import AnalyzerClient
 
-            status = AnalyzerClient().get_status()
-            available = int(status.get("function_count", 0)) > 0
+            status = AnalyzerClient().get_status() or {}
         except Exception as exc:  # server down, socket missing, malformed reply
             self._log(
-                f"Could not ask the analysis server for its index size, so the "
-                f"index tools stay enabled: {exc}",
+                f"Could not read the analysis server status, so every tool group "
+                f"stays enabled: {exc}",
                 level="DEBUG",
             )
-            available = True
+            status = {}
 
-        self._static_analysis_available = available
-        return available
+        self._analysis_status_cache = status
+        return status
 
     def read_function_hint(self, function_name: str) -> str:
         """How to tell this agent to read a function, given the tools it has.
@@ -1146,6 +1171,7 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
                 # This prevents response mixing when multiple agents run concurrently
                 # Pass agent_id for unique context lookup
                 static_analysis_tools = self.include_static_analysis_tools
+                coverage_tools = self.include_coverage_tools
                 mcp_server = create_isolated_mcp_server(
                     agent_id=agent_id,
                     worker_id=agent_id,  # Use agent_id for context isolation
@@ -1155,13 +1181,15 @@ Tool: name(args) - [useful: key findings] or [checked, not relevant]"""
                     include_sp_create_tools=self.include_sp_create_tools,
                     include_direction_tools=self.include_direction_tools,
                     include_static_analysis_tools=static_analysis_tools,
+                    include_coverage_tools=coverage_tools,
                 )
                 self._log(
                     f"Created isolated MCP server: {agent_id} "
                     f"(pov_tools={self.include_pov_tools}, "
                     f"seed_tools={self.include_seed_tools}, "
                     f"sp_tools={self.include_sp_tools}, "
-                    f"static_analysis_tools={static_analysis_tools})",
+                    f"static_analysis_tools={static_analysis_tools}, "
+                    f"coverage_tools={coverage_tools})",
                     level="DEBUG",
                 )
 

--- a/fuzzingbrain/analyzer/server.py
+++ b/fuzzingbrain/analyzer/server.py
@@ -666,6 +666,11 @@ class AnalysisServer:
             else 0,
             "fuzzer_count": len(self.fuzzers),
             "function_count": self._get_function_count(),
+            # Whether the coverage build produced anything. Agents ask this to
+            # decide if the coverage tools are worth offering: advertising them
+            # over a missing build makes them fail in a way that reads as "this
+            # target has no coverage" rather than "coverage was never built".
+            "coverage_available": self.coverage_path is not None,
             "query_count": self.query_count,
             "build_duration": self.build_duration,
             "analysis_duration": self.analysis_duration,

--- a/fuzzingbrain/tools/coverage.py
+++ b/fuzzingbrain/tools/coverage.py
@@ -212,7 +212,13 @@ def run_coverage_fuzzer(
     docker_image = _docker_image.get()
 
     if coverage_fuzzer_dir is None or project_name is None:
-        return False, "", "Coverage context not set. Call set_coverage_context() first."
+        return (
+            False,
+            "",
+            (
+                "No coverage build for this run, so coverage cannot be measured. The coverage build is allowed to fail without stopping a task; trace_pov still traces with gdb against the ASAN binary."
+            ),
+        )
 
     # Check if coverage fuzzer exists
     coverage_fuzzer = coverage_fuzzer_dir / fuzzer_name
@@ -901,7 +907,9 @@ def _run_coverage_impl(
     if coverage_fuzzer_dir is None:
         return CoverageResult(
             success=False,
-            error="Coverage context not set. Call set_coverage_context() first.",
+            error=(
+                "No coverage build for this run, so coverage cannot be measured. The coverage build is allowed to fail without stopping a task; trace_pov still traces with gdb against the ASAN binary."
+            ),
         )
 
     # Decode input
@@ -1014,7 +1022,9 @@ def list_available_fuzzers() -> Dict[str, Any]:
         return {
             "success": False,
             "fuzzers": [],
-            "error": "Coverage context not set",
+            "error": (
+                "No coverage build for this run, so coverage cannot be measured. The coverage build is allowed to fail without stopping a task; trace_pov still traces with gdb against the ASAN binary."
+            ),
         }
 
     if not coverage_fuzzer_dir.exists():
@@ -1151,7 +1161,9 @@ def list_fuzzers_impl() -> Dict[str, Any]:
         return {
             "success": False,
             "fuzzers": [],
-            "error": "Coverage context not set",
+            "error": (
+                "No coverage build for this run, so coverage cannot be measured. The coverage build is allowed to fail without stopping a task; trace_pov still traces with gdb against the ASAN binary."
+            ),
         }
 
     if not coverage_fuzzer_dir.exists():

--- a/fuzzingbrain/tools/mcp_factory.py
+++ b/fuzzingbrain/tools/mcp_factory.py
@@ -29,6 +29,7 @@ def create_isolated_mcp_server(
     include_sp_create_tools: bool = True,
     include_direction_tools: bool = True,
     include_static_analysis_tools: bool = True,
+    include_coverage_tools: bool = True,
 ) -> FastMCP:
     """
     Create an isolated FastMCP server instance with all tools registered.
@@ -60,6 +61,14 @@ def create_isolated_mcp_server(
                                 index is missing". Read, Grep and Glob stay
                                 available either way, so the agent can still
                                 read code.
+        include_coverage_tools: Whether to include the coverage tools (default
+                                True). Set to False when the coverage build
+                                produced nothing: all four read the coverage
+                                build output, and would otherwise fail in a way
+                                that reads as "this target has no coverage".
+                                trace_pov is unaffected -- it traces with gdb
+                                against the ASAN binary and only falls back to
+                                coverage, so it degrades rather than breaking.
 
     Returns:
         A new FastMCP instance with all tools registered
@@ -97,7 +106,8 @@ def create_isolated_mcp_server(
             _register_direction_tools(mcp)
         if include_pov_tools:
             _register_pov_tools(mcp, worker_id=worker_id)
-            _register_coverage_tools(mcp)
+            if include_coverage_tools:
+                _register_coverage_tools(mcp)
 
     return mcp
 

--- a/tests/test_static_analysis_gating.py
+++ b/tests/test_static_analysis_gating.py
@@ -95,3 +95,57 @@ def test_prompts_name_only_tools_the_agent_has(available):
         assert "get_function_source" not in hints and "get_callers" not in hints
         assert "Grep" in hints and "Read" in hints
     assert "png_handle_iCCP" in hints
+
+
+# ------------------------------------------------------------------ coverage
+
+
+COVERAGE = {
+    "run_coverage",
+    "get_coverage_feedback",
+    "check_pov_reaches_target",
+    "list_available_fuzzers",
+}
+
+
+def test_coverage_tools_are_offered_when_the_build_exists():
+    assert COVERAGE <= _names(include_coverage_tools=True)
+
+
+def test_coverage_tools_are_withheld_without_a_coverage_build():
+    """All four read the coverage build output. Offered over a missing build
+    they fail in a way that reads as 'this target has no coverage'."""
+    assert COVERAGE & _names(include_coverage_tools=False) == set()
+
+
+def test_trace_pov_survives_a_missing_coverage_build():
+    """trace_pov traces with gdb against the ASAN binary and only falls back to
+    coverage, so it loses detail rather than breaking. Gating it with the
+    coverage tools would be the mistake this test exists to catch."""
+    assert "trace_pov" in _names(include_coverage_tools=False)
+
+
+def test_coverage_gate_removes_only_the_coverage_tools():
+    on = _names(include_coverage_tools=True)
+    off = _names(include_coverage_tools=False)
+    assert on - off == COVERAGE
+    assert off - on == set()
+
+
+def test_the_two_gates_are_independent():
+    both_off = _names(include_static_analysis_tools=False, include_coverage_tools=False)
+    assert GATED & both_off == set()
+    assert COVERAGE & both_off == set()
+    assert ALWAYS <= both_off, "reading source must survive both gates"
+    assert "trace_pov" in both_off
+
+
+def test_coverage_error_says_the_build_is_missing_not_the_context():
+    """'Coverage context not set' reads as a configuration slip. What actually
+    happened is that the coverage build produced nothing, which is allowed."""
+    from fuzzingbrain.tools import coverage
+
+    ok, _, msg = coverage.run_coverage_fuzzer("some_fuzzer", b"x", None)
+    assert ok is False
+    assert "No coverage build for this run" in msg
+    assert "context" not in msg.lower()


### PR DESCRIPTION
The coverage build is allowed to fail without stopping a task — it logs a warning
and leaves `coverage_path` unset — but its four tools stayed advertised. Called
against a missing build they fail in a way that reads as "this target has no
coverage" rather than "coverage was never built": the same silent misdirection an
empty function index produced, which #130 fixed for the index tools.

## What is gated

All four, because all four read the coverage build output:

| tool | reads |
|---|---|
| `run_coverage` | `_run_coverage_impl` → `_coverage_fuzzer_dir` |
| `get_coverage_feedback` | same |
| `check_pov_reaches_target` | same |
| `list_available_fuzzers` | `_coverage_fuzzer_dir` directly |

I first read `check_pov_reaches_target` as using the ASAN binary. `coverage.py`
holds two unrelated mechanisms — an `llvm-cov` path keyed on
`_coverage_fuzzer_dir`, and a gdb path keyed on `_asan_fuzzer_dir` — and I
attributed the wrong one. `list_available_fuzzers` is likewise not the duplicate
of `get_fuzzers` it looks like: it lists what is in the coverage output
directory.

## What is not gated

`trace_pov` stays. It traces with gdb against the ASAN binary and only falls back
to coverage when gdb fails or misses the target — `pov.py` says so outright,
"Strategy: Try GDB first (reliable crash detection), fallback to coverage" — and
ASAN is a hard requirement for any task that runs at all. Losing coverage costs
it detail, not function.

A test asserts it survives the gate. Gating it alongside the tools it shares a
file with is the obvious mistake here, and it is the same class of mistake as
#130's, where the build-artefact tools would have disappeared with the index
tools.

## How availability is decided

From the analysis server's status, which now reports `coverage_available`. The
index and coverage probes are one cached fetch per agent rather than two round
trips, and a server that cannot be reached reports everything as available — so
an unreachable server degrades to today's behaviour instead of quietly stripping
an agent's tools.

## Also

Rewords the four `"Coverage context not set. Call set_coverage_context() first."`
errors. That phrasing sends the reader after a configuration slip; what actually
happened is that the run has no coverage build, which is permitted.

## Verification

588 tests pass, 13 of them covering the two gates: each removes exactly its own
group and nothing else, source reading survives both, and `trace_pov` survives
the coverage gate. `ruff check .` and `ruff format --check .` clean.