### PR TITLE
Run a delta scan on the diff alone when there is no function index

### DIFF
--- a/fuzzingbrain/worker/strategies/pov_delta.py
+++ b/fuzzingbrain/worker/strategies/pov_delta.py
@@ -135,11 +135,28 @@ class POVDeltaStrategy(POVBaseStrategy):
             f"[Step 1/5] Done in {step_duration:.1f}s - {len(all_changes)} changes ({reachable_count} reachable, {unreachable_count} static-unreachable)"
         )
 
-        # Only skip if NO changes at all (not based on reachability!)
+        # Skip only when the diff itself is empty. An empty change list can also
+        # mean the mapping failed -- get_functions_by_file reads the function
+        # index, so a run without one identifies no changed functions from a
+        # perfectly good diff. Treating those two as the same thing is what made
+        # a worker exit in 0.03s reporting nothing, on a diff that named the
+        # vulnerable function in its own hunk header.
+        #
+        # The mapping is a filter, not a prerequisite: it lets the agent skip
+        # unreachable changes. Without it the agent reads the diff itself, which
+        # is what the delta prompt asks for first anyway.
         if not all_changes:
-            self.log_info("No changes in diff, skipping")
-            result["skip_reason"] = "no_changes"
-            return {"skip": True}
+            if self._diff_has_content():
+                self.log_warning(
+                    "Diff has content but no changed functions were identified "
+                    "-- most likely no function index for this run. Continuing "
+                    "with the raw diff; the agent reads it directly."
+                )
+                result["degraded"] = "no_function_index"
+            else:
+                self.log_info("No changes in diff, skipping")
+                result["skip_reason"] = "no_changes"
+                return {"skip": True}
 
         # Log the unreachable functions that will now be analyzed
         if unreachable_count > 0:
@@ -170,7 +187,12 @@ class POVDeltaStrategy(POVBaseStrategy):
             "Finding suspicious points in ALL changes (ignoring reachability filter)..."
         )
 
-        if not self._all_changes:
+        # An empty list here means the mapping produced nothing, not that there
+        # is nothing to analyse -- Step 1 already refused to skip when the diff
+        # has content. The generator handles it: the changed-functions section
+        # of its prompt renders empty, and the first instruction is to call
+        # get_diff, so the agent works from the diff itself.
+        if not self._all_changes and not self._diff_has_content():
             self.log_warning("No changes found, cannot find suspicious points")
             return []
 
@@ -247,6 +269,17 @@ class POVDeltaStrategy(POVBaseStrategy):
         self._save_reachability_report(result)
 
         return result
+
+    def _diff_has_content(self) -> bool:
+        """Whether there is a diff to hand the agent, mapping aside."""
+        if not self.diff_path or not self.diff_path.exists():
+            return False
+        try:
+            return bool(
+                self.diff_path.read_text(encoding="utf-8", errors="replace").strip()
+            )
+        except OSError:
+            return False
 
     def _get_all_diff_changes(self) -> List[FunctionChange]:
         """

--- a/tests/test_delta_degrades_without_index.py
+++ b/tests/test_delta_degrades_without_index.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A delta scan runs on the diff alone when there is no function index.
+
+Mapping changed lines to changed functions reads the function index, so a run
+without one identifies nothing from a perfectly good diff. That has to degrade,
+not skip: the mapping is a filter that lets the agent ignore unreachable
+changes, and the delta prompt's first instruction is to read the diff anyway.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from fuzzingbrain.worker.strategies.pov_delta import POVDeltaStrategy
+
+DIFF = """diff --git a/pngrutil.c b/pngrutil.c
+--- a/pngrutil.c
++++ b/pngrutil.c
+@@ -1419,12 +1419,13 @@ png_handle_iCCP(png_structrp png_ptr, png_inforp info_ptr)
+-      char keyword[81];
++      wpng_byte keyword[max_keyword_wbytes];
+-      read_length = 81;
++      read_length = sizeof(keyword);
+"""
+
+
+class _Strategy(POVDeltaStrategy):
+    """Only the diff plumbing; nothing else in the strategy is exercised."""
+
+    def __init__(self, diff_path):
+        self.diff_path = diff_path
+        self._all_changes = []
+        self.logged = []
+
+    def _log(self, msg, level="INFO"):
+        self.logged.append((level, msg))
+
+    log_info = log_warning = log_error = log_debug = _log
+
+
+@pytest.fixture
+def diff_file(tmp_path):
+    p = tmp_path / "ref.diff"
+    p.write_text(DIFF)
+    return p
+
+
+def test_a_diff_with_content_is_recognised(diff_file):
+    assert _Strategy(diff_file)._diff_has_content() is True
+
+
+def test_an_empty_diff_is_not_content(tmp_path):
+    empty = tmp_path / "ref.diff"
+    empty.write_text("   \n\n")
+    assert _Strategy(empty)._diff_has_content() is False
+
+
+def test_a_missing_diff_is_not_content(tmp_path):
+    assert _Strategy(tmp_path / "absent.diff")._diff_has_content() is False
+
+
+def test_no_diff_path_at_all_is_not_content():
+    assert _Strategy(None)._diff_has_content() is False
+
+
+def test_the_hunk_header_names_the_function_the_index_would_have_found(diff_file):
+    """Why degrading is reasonable: git puts the enclosing function in the hunk
+    header, so the agent reading the diff sees what the mapping would report."""
+    assert "png_handle_iCCP" in diff_file.read_text()
+
+
+def test_generator_prompt_survives_an_empty_change_list():
+    """The changed-functions section renders empty rather than breaking, and the
+    prompt still tells the agent to call get_diff first."""
+    from fuzzingbrain.agents.sp_generators import DeltaSPGenerator
+
+    section = DeltaSPGenerator._format_changed_functions_section(SimpleNamespace(), [])
+    assert section == ""


### PR DESCRIPTION
Mapping changed lines to changed functions reads the function index —
`get_functions_by_file` queries the collection directly, not through MCP, so
gating the tools in #130 and #131 did nothing for it. A run without an index
identified zero changed functions from a perfectly good diff, and the strategy
treated that as "no changes" and skipped:

```
[Worker] [POV Delta Strategy] Found 0 changed functions
[Worker] [POV Delta Strategy] No changes in diff, skipping
[Worker] Status: COMPLETED   Elapsed: 0.0s   POVs: 0
API Cost: $0.00
```

Success, in 0.03 s, having discarded a diff whose own hunk header named the
vulnerable function:

```
@@ -1419,12 +1419,13 @@ png_handle_iCCP(png_structrp png_ptr, png_inforp info_ptr)
-      char keyword[81];
+      wpng_byte keyword[max_keyword_wbytes];
```

## The change

Two conditions were conflated. "The mapping found nothing" and "the diff is
empty" are different facts, and only the second is a reason not to work.

The mapping is a filter — it lets the agent skip changes unreachable from this
harness — not a prerequisite for reading a diff. The delta prompt's first
instruction is already `READ THE DIFF: Call get_diff`, and the changed-functions
section of that prompt renders empty rather than breaking. So the agent has what
it needs without the mapping; it just loses the shortlist.

Degrade when the diff has content, skip only when it does not, and record which
happened. Both gates needed it: the second, just before SP generation, would
otherwise have returned an empty list after the first let the run through.

## Same shape as the two previous PRs

| missing | before | after |
|---|---|---|
| function index | 9 tools returned nothing, read as "no such function" | tools not offered (#130) |
| coverage build | 4 tools failed, read as "no coverage here" | tools not offered (#131) |
| function index | delta scan skipped in 0.03 s | delta scan runs on the diff |

A capability that is missing should cost precision, not the whole run.

## Verification

594 tests pass, 6 new: the content check across a real diff, an empty one, a
missing file and no path at all; that the hunk header carries the function name
the mapping would have reported; and that the generator's prompt section renders
empty rather than raising.

Not verified: no run has exercised the degraded path end to end. The tests cover
the branch and the prompt, not whether an agent handed a raw diff produces
useful suspicious points.