### PR TITLE
Stop the SP generator from going blind without a function index

### DIFF
--- a/fuzzingbrain/agents/direction_planning_agent.py
+++ b/fuzzingbrain/agents/direction_planning_agent.py
@@ -278,6 +278,7 @@ When assigning risk levels, prioritize directions that handle code patterns dete
 
     def get_initial_message(self, **kwargs) -> str:
         """Generate initial message for direction planning."""
+        source_hint = self.read_function_hint(self.fuzzer)
         fuzzer_code = kwargs.get("fuzzer_code", "")
         reachable_count = kwargs.get("reachable_count", 0)
         vuln_hint = kwargs.get("vuln_hint", "") or ""
@@ -320,7 +321,7 @@ This code shows EXACTLY how fuzzer input enters the target library.
 Understanding this is MANDATORY - it defines what code is exploitable.
 
 ```c
-{fuzzer_code if fuzzer_code else "// Fuzzer source not provided - use get_function_source to read it"}
+{fuzzer_code if fuzzer_code else f"// Fuzzer source not provided - read it with {source_hint}"}
 ```
 
 ## Codebase Information
@@ -328,7 +329,7 @@ Understanding this is MANDATORY - it defines what code is exploitable.
 
 ## Your Task
 
-1. **FIRST**: If fuzzer code is not shown above, read it with get_function_source("{self.fuzzer}")
+1. **FIRST**: If fuzzer code is not shown above, read it: {source_hint}
 2. Understand how input flows from the fuzzer into the library
 3. Use get_call_graph to understand the call structure
 4. Group reachable functions into logical directions

--- a/fuzzingbrain/agents/sp_generators.py
+++ b/fuzzingbrain/agents/sp_generators.py
@@ -130,24 +130,32 @@ class SPGeneratorBase(BaseAgent):
         """
         Filter tools for SP generation mode.
 
-        Allow:
-        - create_suspicious_point: main output
-        - get_function_source: read code
-        - get_callers/get_callees: call graph exploration
-        - get_diff: for delta mode
+        Exclude, rather than list what is allowed:
+        - update_suspicious_point: verification writes verdicts, generation does not
+        - find_all_paths, check_reachability: too slow for a first pass
+        - the POV and coverage tools: nothing here runs a binary
 
-        Exclude:
-        - update_suspicious_point: verification only
-        - find_all_paths, check_reachability: too slow
+        This used to be an allow-list of five names, which broke as soon as tool
+        availability became conditional. Three of the five read the function
+        index, so a run without one left this agent holding get_diff and
+        create_suspicious_point -- two tools, no way to read code, and it still
+        had to name a vulnerable function. It also silently withheld Read, Grep
+        and Glob, because an allow-list cannot know about a tool added after it
+        was written.
         """
-        allowed = {
-            "create_suspicious_point",
-            "get_function_source",
-            "get_callers",
-            "get_callees",
-            "get_diff",
+        excluded = {
+            "update_suspicious_point",
+            "find_all_paths",
+            "check_reachability",
+            "create_pov",
+            "verify_pov",
+            "trace_pov",
+            "run_coverage",
+            "get_coverage_feedback",
+            "check_pov_reaches_target",
+            "list_available_fuzzers",
         }
-        return [t for t in tools if t.get("function", {}).get("name") in allowed]
+        return [t for t in tools if t.get("function", {}).get("name") not in excluded]
 
     async def _get_tools(self, client) -> List[Dict[str, Any]]:
         """Get tools from MCP server, filtered for generation mode."""
@@ -570,6 +578,7 @@ class LargeFullSPGenerator(FullSPGenerator):
 
     def get_initial_message(self, **kwargs) -> str:
         """Generate initial message with sliding window support."""
+        source_hint = self.read_function_hint(self.fuzzer)
         func_lines = self.function_source.count("\n") + 1
 
         if self.use_sliding_window and func_lines > self.LARGE_FUNCTION_THRESHOLD:
@@ -596,7 +605,7 @@ class LargeFullSPGenerator(FullSPGenerator):
 
 This function is large ({func_lines} lines). I'll show you sections in windows.
 - Analyze each window for vulnerabilities
-- Use get_function_source to see more context if needed
+- Use {source_hint} to see more context if needed
 - Create SPs as you find issues
 - Request next window when ready
 
@@ -862,6 +871,7 @@ Only find vulnerabilities that are:
         message += self._format_fuzzer_code_section(fuzzer_code)
         message += self._format_changed_functions_section(reachable_changes)
 
+        source_hint = self.read_function_hint(self.fuzzer)
         message += f"""## Your Task
 
 Follow these steps IN ORDER:
@@ -869,7 +879,7 @@ Follow these steps IN ORDER:
 1. **READ THE DIFF**: Call get_diff to see what code was changed
 
 2. **ANALYZE ALL CHANGED FUNCTIONS** (including static-unreachable!):
-   - Read each function's source code with get_function_source
+   - Read each function's source code: {source_hint}
    - Look for {self.sanitizer}-detectable vulnerabilities:
      - {self._get_sanitizer_vuln_types()}
 """

--- a/fuzzingbrain/worker/strategies/pov_delta.py
+++ b/fuzzingbrain/worker/strategies/pov_delta.py
@@ -394,9 +394,23 @@ class POVDeltaStrategy(POVBaseStrategy):
             for c in self._all_changes
         ]
 
-        if not changed_functions:
-            self.log_warning("No changed functions, skipping delta seeds generation")
+        # An empty changed-functions list does not mean there is nothing to seed
+        # from. It also happens when the mapping had no function index to read,
+        # and by this point the find phase has already produced suspicious
+        # points from the raw diff -- each naming a function, a vulnerability
+        # type and a description, which is richer seeding context than the list
+        # this used to require. Only give up when there is no lead at all.
+        if not changed_functions and not suspicious_points:
+            self.log_warning(
+                "No changed functions and no suspicious points, skipping delta "
+                "seeds generation"
+            )
             return 0
+        if not changed_functions:
+            self.log_info(
+                f"No changed functions mapped; seeding from "
+                f"{len(suspicious_points)} suspicious point(s) instead"
+            )
 
         # Prepare suspicious points context
         sp_context = [

--- a/tests/test_delta_degrades_without_index.py
+++ b/tests/test_delta_degrades_without_index.py
@@ -76,3 +76,32 @@ def test_generator_prompt_survives_an_empty_change_list():
 
     section = DeltaSPGenerator._format_changed_functions_section(SimpleNamespace(), [])
     assert section == ""
+
+
+# ------------------------------------------------------------------ seeding
+
+
+def test_seeding_falls_back_to_suspicious_points(diff_file):
+    """Seed generation used to require the mapped function list, so a run
+    without an index produced no diff-guided seeds even after the find phase
+    had produced suspicious points -- which name a function, a vulnerability
+    type and a description, and are richer seeding context than that list."""
+    import inspect
+
+    from fuzzingbrain.worker.strategies import pov_delta
+
+    src = inspect.getsource(pov_delta.POVDeltaStrategy._generate_delta_seeds)
+    assert "not changed_functions and not suspicious_points" in src, (
+        "seeding must give up only when there is no lead at all"
+    )
+
+
+def test_seed_agent_tolerates_an_empty_change_list():
+    """The prompt section renders only when there are changes, so handing it an
+    empty list degrades the prompt rather than breaking the agent."""
+    import inspect
+
+    from fuzzingbrain.fuzzer import seed_agent
+
+    src = inspect.getsource(seed_agent)
+    assert "if changed_functions:" in src

--- a/tests/test_static_analysis_gating.py
+++ b/tests/test_static_analysis_gating.py
@@ -149,3 +149,85 @@ def test_coverage_error_says_the_build_is_missing_not_the_context():
     assert ok is False
     assert "No coverage build for this run" in msg
     assert "context" not in msg.lower()
+
+
+# ------------------------------------------------------------------ per-agent filters
+
+
+def _filtered(cls, names):
+    """What one agent class keeps out of a given tool list."""
+    fake = [{"function": {"name": n}} for n in names]
+    return {t["function"]["name"] for t in cls._filter_tools_for_mode(None, fake)}
+
+
+WITH_INDEX = [
+    "Read",
+    "Grep",
+    "Glob",
+    "get_diff",
+    "get_function_source",
+    "get_callers",
+    "get_callees",
+    "create_suspicious_point",
+    "analyzer_status",
+]
+WITHOUT_INDEX = [
+    n
+    for n in WITH_INDEX
+    if n not in {"get_function_source", "get_callers", "get_callees"}
+]
+
+
+def test_sp_generator_can_read_code_without_an_index():
+    """The generator filtered tools through an allow-list of five names, three
+    of which read the function index. A run without one left it holding
+    get_diff and create_suspicious_point -- two tools, no way to read code, and
+    it still had to name a vulnerable function. Observed in a real run:
+    'Available tools: get_diff, create_suspicious_point'."""
+    from fuzzingbrain.agents.sp_generators import SPGeneratorBase
+
+    kept = _filtered(SPGeneratorBase, WITHOUT_INDEX)
+    assert {"Read", "Grep", "Glob"} <= kept
+    assert "create_suspicious_point" in kept
+
+
+def test_sp_generator_keeps_the_index_tools_when_they_exist():
+    from fuzzingbrain.agents.sp_generators import SPGeneratorBase
+
+    kept = _filtered(SPGeneratorBase, WITH_INDEX)
+    assert {"get_function_source", "get_callers", "get_callees"} <= kept
+
+
+def test_sp_generator_still_excludes_what_it_should():
+    """Generation writes suspicious points; it does not verify them or run
+    binaries."""
+    from fuzzingbrain.agents.sp_generators import SPGeneratorBase
+
+    kept = _filtered(
+        SPGeneratorBase,
+        WITH_INDEX
+        + ["update_suspicious_point", "create_pov", "verify_pov", "run_coverage"],
+    )
+    assert (
+        kept & {"update_suspicious_point", "create_pov", "verify_pov", "run_coverage"}
+        == set()
+    )
+
+
+def test_verifier_can_read_code_without_an_index():
+    from fuzzingbrain.agents.sp_verifier import SPVerifier
+
+    assert {"Read", "Grep", "Glob"} <= _filtered(SPVerifier, WITHOUT_INDEX)
+
+
+def test_agent_filters_do_not_use_allow_lists():
+    """An allow-list cannot know about a tool added after it was written, which
+    is how Read, Grep and Glob stayed invisible to the generator."""
+    import inspect
+
+    from fuzzingbrain.agents.sp_generators import SPGeneratorBase
+    from fuzzingbrain.agents.sp_verifier import SPVerifier
+
+    for cls in (SPGeneratorBase, SPVerifier):
+        src = inspect.getsource(cls._filter_tools_for_mode)
+        assert "not in" in src, f"{cls.__name__} filters by exclusion, not inclusion"


### PR DESCRIPTION
Found by running the degraded path from #132 rather than by reading it. A libpng
delta scan with no introspector produced a suspicious point and two POVs in
2m46s for \$1.59 — which read as a clean success until the agent logs showed:

```
[SPG-Delta] Available tools: get_diff, create_suspicious_point
[SPV-1]     Available tools: get_diff, Read, Grep, Glob, analyzer_status, ...
```

Two tools for the generator, fourteen for the verifier, in the same run.

## The allow-list

`sp_generators` filtered tools through five hardcoded names, three of which read
the function index. Gating those (#130) left the generator holding the diff and
the tool it writes findings with. It had to name a vulnerable function with no
way to read code — and it did, from the diff alone, then tried
`get_file_content`, got `Unknown tool`, and had no `Grep` to fall back to.

`Read`, `Grep` and `Glob` had never been visible to it. An allow-list cannot know
about a tool added after it was written.

It is now an exclusion list, matching what the verifier already did — which is
exactly why the verifier had 14 tools. The intent was always exclusive
(generation does not verify findings or run binaries), so stating it as an
allow-list wrote it backwards. Without an index the generator now has 7 tools
instead of 2.

I also had the wrong story about that run: the diff reading, the `Grep` for the
function and the three searches chasing `wpng_byte` down to `png_uint_16` were
all the verifier's. The generator was doing none of it.

## Prompts naming tools the agent may not have

`sp_generators` and `direction_planning_agent` still asked for
`get_function_source` outright, one of them as a first instruction. Only
`sp_verifier` and `pov_agent` were fixed when `read_function_hint` was
introduced. All four now ask for whichever tool the run has.

## The third gate

Seed generation still required the mapped function list, so a degraded run
produced no diff-guided seeds even though the find phase had already produced
suspicious points — which name a function, a type and a description, and are
better seeding context than that list. It gives up only when there is no lead at
all.

## Audit

No other allow-list exists: the `mcp_factory` switches register by group, the
verifier excludes, the report agent only appends, and the seed agent takes an
exclusive branch. A test asserts both filters keep excluding rather than listing,
so changing one back fails.

601 tests pass; `ruff check .` and `ruff format --check .` clean.

## Still open

The POV construction agent failed again in that run — 462 s, 47 `create_pov`
calls, zero POVs generated. Both POVs came from libFuzzer. My earlier guess that
it was starved of the harness source is wrong: it had `get_fuzzer_source` and
`Read` this time and still failed.