### PR TITLE
Fix the tool layer's silent gaps, and give the README an example that builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ internal/
 
 # uv, when the bootstrap installs it locally
 .uv/
+fuzzingbrain/eval_server
+fuzzingbrain/dashboard

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # All You Need Is a Fuzzing Brain
 
-<img src="https://img.shields.io/badge/Python-3.10+-blue?style=for-the-badge&logo=python&logoColor=white" alt="Python">
+<img src="https://img.shields.io/badge/Python-3.11-blue?style=for-the-badge&logo=python&logoColor=white" alt="Python">
 <img src="https://img.shields.io/badge/Docker-Required-2496ED?style=for-the-badge&logo=docker&logoColor=white" alt="Docker">
 <img src="https://img.shields.io/badge/License-Apache_2.0-green?style=for-the-badge" alt="License">
 
@@ -25,43 +25,136 @@ patches — with every finding dynamically verified to eliminate hallucinations.
 
 | Requirement | Notes |
 |---|---|
-| **Docker** | Running, with permission to pull images and run containers |
-| **Python** | Not required up front — `uv` fetches the version in `.python-version` (3.11) so every machine runs the same interpreter |
+| **Docker** | Running, and your user able to run containers (`docker ps` without `sudo`) |
+| **Python** | Not required up front — `uv` fetches the version in `.python-version` (3.11), so the run does not depend on whatever `python3` happens to be first on `PATH` |
 | **One LLM API key** | Anthropic, OpenAI, or Google Gemini |
-| **Linux** | Recommended (OSS-Fuzz builds are happiest on Linux) |
+| **Linux** | Recommended; OSS-Fuzz builds are happiest there |
+| **Disk** | Tens of GB. An OSS-Fuzz build tree is several GB per target and large projects (wireshark, freerdp) transiently need far more |
 
-You do **not** need to install Python dependencies or start MongoDB/Redis by
-hand — `FuzzingBrain.sh` bootstraps the virtualenv, installs requirements, and
-starts the infrastructure containers automatically.
+## Setting up
 
-## Quick Start
+There is no separate install step. `FuzzingBrain.sh` bootstraps everything the
+first time it runs:
 
 ```bash
 git clone https://github.com/fuzzingbrain/afc-crs-all-you-need-is-a-fuzzing-brain.git
 cd afc-crs-all-you-need-is-a-fuzzing-brain
 
-# 1. Configure API keys
 cp .env.example .env
 $EDITOR .env          # add at least one API key
-
-# 2. Run a full scan (first run also creates the venv + installs deps)
-./FuzzingBrain.sh https://github.com/OwenSanzas/libpng.git
 ```
 
-On the first run the script will:
+On that first run the script:
 
-1. create `venv/` and install `requirements.txt`,
-2. start the `fuzzingbrain-mongodb` and `fuzzingbrain-redis` containers,
-3. clone the target, build its fuzzers via OSS-Fuzz, and run the pipeline.
+1. installs `uv` into `.uv/` if it is not already on `PATH` (a single static
+   binary; nothing is installed system-wide),
+2. creates `venv/` on **Python 3.11** — the version pinned in `.python-version`,
+   rebuilding the venv if an existing one is on a different version,
+3. installs `requirements.txt` into it, and records the file's hash in
+   `venv/.deps_installed` so later runs skip the install unless requirements
+   change,
+4. starts the `fuzzingbrain-mongodb` and `fuzzingbrain-redis` containers.
 
-If `.env` is missing, the script creates one from `.env.example` and asks you to
-fill in a key before re-running.
+If `.env` is missing it is created from `.env.example` and the run stops so you
+can fill in a key.
 
-> **Tip — pick a build-ready target.** The fuzzer must build before any bug
-> hunting can start. `https://github.com/OwenSanzas/libpng.git` is a known-good
-> example. Some upstream `HEAD`s have drifted from their OSS-Fuzz build scripts
-> (e.g. relocated source files) and will fail to build; prefer a pinned commit
-> with `-v <commit>` when in doubt.
+To set the environment up without starting a scan:
+
+```bash
+./FuzzingBrain.sh --help      # bootstraps, prints options, exits
+```
+
+If you would rather manage the virtualenv yourself:
+
+```bash
+python3.11 -m venv venv
+./venv/bin/pip install -r requirements.txt
+```
+
+Only `requirements.txt` matters here — there is no `pyproject.toml` and no lock
+file, so `uv` is a convenience for pinning the interpreter, not a hard
+dependency.
+
+## Running an example
+
+Each entry under [`examples/`](examples/) is a task file or a short script,
+short enough to read before running it.
+
+**Start here** — a delta scan of an AIxCC Final Competition challenge, driven by
+a task file:
+
+```bash
+./FuzzingBrain.sh examples/07_aixcc_challenge/cu-delta-02.json
+```
+
+Every reference in it is pinned to a commit, so it builds the same way today as
+it will next month. It has a known defect to find and a reference PoV to compare
+against, which is what makes it worth running first: a scan that reports nothing
+is only informative if you know there was something to report. That directory's
+README says what the defect is and how to tell whether a run found it.
+
+Measured on a first run: about four minutes to build the Docker image, three and
+a half more for the seventeen fuzzers, then the agents. It finished in fourteen
+and a half minutes having spent $2.14 of the $20 `budget_limit` its task file
+sets. That cap is a hard stop rather than a hint — set one on every run until
+you know what a scan costs on your targets. Both builds are cached, so a second
+run on the same target starts at the agents.
+
+| Example | What it does |
+|---|---|
+| [`examples/07_aixcc_challenge`](examples/07_aixcc_challenge) | The task file above, and what its result should look like |
+| [`examples/04_json_config`](examples/04_json_config) | Runs driven by a JSON task file instead of flags |
+| [`examples/03_local_scan`](examples/03_local_scan) | Full scan from a GitHub URL |
+| [`examples/05_delta_scan`](examples/05_delta_scan) | Scan only what changed between two commits |
+| [`examples/06_job_types`](examples/06_job_types) | `pov`, `patch` and `harness` task types |
+| [`examples/01_rest_api`](examples/01_rest_api) | REST server on port 18080 |
+| [`examples/02_mcp_server`](examples/02_mcp_server) | MCP server, to drive from an MCP client |
+
+> **Pin what you scan against.** Examples 03, 05 and 06 target a `libpng` fork
+> and do not currently build: OSS-Fuzz's `libpng` recipe copies `build.sh` out
+> of `pnggroup/libpng@master` rather than shipping its own, so upstream tooling
+> compiles a harness the pinned commit does not contain and the build fails with
+> `no such file or directory: libpng_colormap_fuzzer.cc`. Most OSS-Fuzz projects
+> keep `build.sh` in OSS-Fuzz and do not have this problem; a challenge, which
+> pins its tooling ref as well, cannot have it at all.
+
+A delta scan does not need a call graph. Without one the worker hands the raw
+diff to the agent, which reads it with the same file tools it uses everywhere
+else, and says so in the log:
+
+```
+Diff has content but no changed functions were identified -- most likely no
+function index for this run. Continuing with the raw diff
+```
+
+A call graph makes the scan sharper rather than possible: it maps the diff onto
+named functions and tells the worker which of them the harness can actually
+reach, so the agent starts from a short list instead of a patch. Building one
+needs `enable_static_analysis` in the task file, which runs fuzz-introspector
+during the build; a graph built earlier can be handed to a later run with
+`--prebuild-dir`. [`examples/aixcc-challenges/`](examples/aixcc-challenges/)
+holds a manifest per public AIxCC challenge — the refs and harnesses each one
+pins. The graphs themselves are not in the repository; they are build output,
+and each is hundreds of megabytes.
+
+### What a run leaves behind
+
+```
+workspace/<project>_<task_id>/results/
+├── povs/        # verified proof-of-vulnerability inputs
+├── patches/     # proposed fixes
+└── report.json  # run summary
+logs/<project>_<task_id>_<timestamp>/
+```
+
+Nothing is reported that has not crashed a real build: every candidate input is
+executed against the built fuzzer and kept only if the sanitizer fires.
+
+> **Pick a build-ready target.** The fuzzer has to build before any bug hunting
+> starts, and a target that built last month may not build today: an OSS-Fuzz
+> recipe that clones a dependency at `master` picks up whatever is there now.
+> Check `logs/<run>/build/*.log` first when a run reports nothing — a failed
+> build and a clean scan do not look alike there, but they can in a summary.
 
 ## Usage
 
@@ -99,7 +192,7 @@ Run `./FuzzingBrain.sh --help` for the full list.
 
 ```bash
 # Full scan with a $20 budget cap
-./FuzzingBrain.sh --budget 20 https://github.com/OwenSanzas/libpng.git
+./FuzzingBrain.sh --budget 20 <git_url>
 
 # Delta scan between two commits
 ./FuzzingBrain.sh -b <base> -d <delta> https://github.com/user/repo.git
@@ -109,19 +202,6 @@ Run `./FuzzingBrain.sh --help` for the full list.
 
 # Start the REST API server (port 18080)
 ./FuzzingBrain.sh --api
-```
-
-## Results
-
-Output is written under the task's workspace:
-
-```
-workspace/<project>_<task_id>/
-└── results/
-    ├── povs/        # verified proof-of-vulnerability inputs
-    ├── patches/     # proposed fixes
-    └── report.json  # run summary
-logs/<project>_<task_id>_<timestamp>/   # full run logs
 ```
 
 ## How it works
@@ -157,13 +237,16 @@ See [`examples/`](examples/) for runnable configurations of each mode.
 | `.env file created … add your API keys` | Edit `.env`, add a key, re-run |
 | Fuzzer build fails immediately | The target doesn't match its OSS-Fuzz build script; pin a commit with `-v`, or pick a build-ready target |
 | `docker: permission denied` | Add your user to the `docker` group, or run with sufficient privileges |
-| Dependencies re-install every run | Delete `venv/.deps_installed` to force a clean reinstall |
+| Dependencies re-install on every run | The hash in `venv/.deps_installed` no longer matches `requirements.txt` — expected after editing it. Delete that file to force a reinstall on purpose |
+| Wrong Python in `venv/` | The venv is rebuilt automatically when it is not on the version in `.python-version`; `rm -rf venv` if it is wedged |
+| Delta scan finds nothing in under a second | No call graph, so the diff maps to no functions. Pass `--prebuild-dir` (see [`examples/aixcc-challenges/`](examples/aixcc-challenges/)) |
 | Want to reset infra | `docker rm -f fuzzingbrain-mongodb fuzzingbrain-redis` |
 
 ## Development
 
 ```bash
-python3 -m venv venv && ./venv/bin/pip install -r requirements.txt
+# the pinned interpreter; `./FuzzingBrain.sh --help` does this for you
+python3.11 -m venv venv && ./venv/bin/pip install -r requirements.txt
 ./venv/bin/python -m pytest tests/
 ```
 

--- a/examples/07_aixcc_challenge/README.md
+++ b/examples/07_aixcc_challenge/README.md
@@ -1,0 +1,103 @@
+# AIxCC challenge — curl `cu-delta-02`
+
+A delta scan of a real AIxCC Final Competition challenge, against the public
+challenge repositories. Nothing here is local to one machine:
+
+```bash
+./FuzzingBrain.sh examples/07_aixcc_challenge/cu-delta-02.json
+```
+
+## Why this is the reference example
+
+Every reference in this file is pinned, which is the whole point. An OSS-Fuzz
+project that clones its dependencies at `master` builds differently on different
+days — the `libpng` demo target used elsewhere in `examples/` copies its
+`build.sh` out of `pnggroup/libpng@master`, so upstream tooling now compiles a
+harness the scanned commit does not contain, and the build fails. A challenge
+cannot drift like that: `.aixcc/challenge.yaml` names the exact `base_ref`,
+`delta_ref` and `fuzz_tooling_ref`, and this config repeats them as commit SHAs.
+
+It also exercises the parts of the system a plain repository never reaches: the
+challenge ships `.aixcc/` containing the vulnerability's location, a reference
+PoV blob and the reference patch, so the run has something real to strip. The
+posture banner is where you confirm it did:
+
+```
+.aixcc         removed (1 path)
+.git           kept (remove_git off)
+workspace      confined to curl_<task_id>/repo
+```
+
+If that line reads `not present`, sanitisation did not run and the findings from
+that run mean nothing.
+
+## The target
+
+| | |
+|---|---|
+| Challenge | `cu-delta-02` — curl-006, "medium difficulty crash" |
+| Defect | CWE-476, NULL pointer dereference |
+| Location | `lib/totallyfineprotocl.c:228-232` |
+| Harness | `curl_fuzzer_ws` |
+| Trigger | the server writing a specific response mid-connection |
+
+The delta adds 613 lines across 17 files, including a whole invented protocol
+and a test server for it. This is not a bug blind fuzzing stumbles over: the
+reference PoV is 155 bytes of structured WebSocket input.
+
+Knowing the answer is what makes the example useful — you can tell whether a run
+worked. The system never sees any of it; `.aixcc` is deleted before the build,
+and the agents' file tools refuse any path containing `.aixcc` or `.git`.
+
+## Scope
+
+One harness and one sanitizer, so one worker:
+
+```json
+"sanitizers": ["address"],
+"fuzzers": ["curl_fuzzer_ws"]
+```
+
+`curl_fuzzer_ws` is the harness the challenge's own `vuln.yaml` names for this
+PoV. The challenge defines seventeen; a competition run dispatches a worker per
+`{fuzzer, sanitizer}` pair, and dropping `"fuzzers"` from the config does that
+here. Start with one — it is the pair that reaches curl-006, and it keeps the
+first run cheap enough to read end to end.
+
+## Naming the harness source
+
+```json
+"fuzzer_sources": {
+  "curl_fuzzer_ws": [
+    ".../curl_fuzzer/curl_fuzzer.cc",
+    ".../curl_fuzzer/curl_fuzzer.h"
+  ]
+}
+```
+
+Paths resolve against the workspace, so a path under `fuzz-tooling/` or `repo/`
+works. This is worth setting explicitly whenever a harness is more than one
+file, and curl is the case that shows why.
+
+curl builds all seventeen of its named harnesses from a single
+`curl_fuzzer.cc`, which reads its input as a TLV stream — and every TLV type
+number is a `#define` in `curl_fuzzer.h`. Given only the `.cc`, an agent has to
+infer that table. It infers the obvious thing: that the server-response slots
+run consecutively from `TLV_TYPE_RESPONSE0 = 2`. They do not — slot 0 is 2 and
+the rest jump to 17, 18, 19, with 3, 4 and 5 meaning USERNAME, PASSWORD and
+POSTFIELDS. An agent working from that guess writes an input that is otherwise
+completely correct, down to the trigger string and its CRLF, and puts it in a
+POST body. Nothing crashes, and the run looks like a failure of reasoning
+rather than a missing header.
+
+## Cost and time
+
+`budget_limit` is USD of LLM spend and a hard stop, not a hint. The build
+dominates a first run: the Docker image takes about four minutes and the
+seventeen fuzzers about five, both cached afterwards.
+
+## Other challenges
+
+The same shape works for any AIxCC challenge — copy the config and replace the
+four refs with the ones in that challenge's `.aixcc/challenge.yaml`, and the
+harness with the one its `vuln.yaml` names.

--- a/examples/07_aixcc_challenge/cu-delta-02.json
+++ b/examples/07_aixcc_challenge/cu-delta-02.json
@@ -1,0 +1,25 @@
+{
+  "repo_url": "https://github.com/aixcc-finals/afc-curl.git",
+  "project_name": "curl",
+  "task_type": "pov",
+  "scan_mode": "delta",
+  "base_commit": "332850107d906154ec53c0b3dfc16a46fea692a4",
+  "delta_commit": "b98c8446f9d99431852155187a572e10ddfd8e7e",
+  "fuzz_tooling_url": "https://github.com/aixcc-finals/oss-fuzz-aixcc.git",
+  "fuzz_tooling_ref": "challenge-state/cu-delta-02",
+  "sanitizers": [
+    "address"
+  ],
+  "fuzzers": [
+    "curl_fuzzer_ws"
+  ],
+  "remove_git": true,
+  "fuzzer_sources": {
+    "curl_fuzzer_ws": [
+      "fuzz-tooling/build/out/curl_coverage/src/curl_fuzzer/curl_fuzzer.cc",
+      "fuzz-tooling/build/out/curl_coverage/src/curl_fuzzer/curl_fuzzer.h"
+    ]
+  },
+  "timeout_minutes": 45,
+  "budget_limit": 20.0
+}

--- a/fuzzingbrain/agents/base.py
+++ b/fuzzingbrain/agents/base.py
@@ -252,22 +252,32 @@ class BaseAgent(ABC):
 
         Asked of the server rather than threaded down from the task, because
         what a run produced is a fact about its data, not about the kind of
-        agent reading it. On failure every capability reads as available, so a
-        server that cannot be reached degrades to today's behaviour rather than
-        silently stripping an agent's tools.
+        agent reading it.
+
+        A failed read returns ``{}``, and the two gates then read that empty
+        dict in opposite directions -- deliberately. The index tools speak to
+        this same socket, so a server that cannot be reached is a server whose
+        index tools could not have answered anyway, and their gate closes. The
+        coverage tools read the coverage build directly and never touch this
+        socket, so an unread status says nothing about them and their gate
+        stays open.
         """
         cached = getattr(self, "_analysis_status_cache", None)
         if cached is not None:
             return cached
 
         try:
-            from ..analyzer.client import AnalyzerClient
+            from ..tools.analyzer import analyzer_status
 
-            status = AnalyzerClient().get_status() or {}
+            reply = analyzer_status() or {}
+            if not reply.get("success"):
+                raise RuntimeError(reply.get("error") or "no reply from the server")
+            status = reply.get("status") or {}
         except Exception as exc:  # server down, socket missing, malformed reply
             self._log(
-                f"Could not read the analysis server status, so every tool group "
-                f"stays enabled: {exc}",
+                f"Could not read the analysis server status ({exc}), so the "
+                f"index tools stay off -- they use this same socket -- while "
+                f"the coverage tools, which do not, stay on",
                 level="DEBUG",
             )
             status = {}

--- a/fuzzingbrain/agents/pov_agent.py
+++ b/fuzzingbrain/agents/pov_agent.py
@@ -303,12 +303,16 @@ class POVAgent(BaseAgent):
         }
 
     def _configure_context(self, ctx) -> None:
-        """Configure agent context with SP ID."""
+        """Configure agent context with SP ID, and register the POV tool context."""
         if self.suspicious_point:
             sp_id = self.suspicious_point.get(
                 "suspicious_point_id"
             ) or self.suspicious_point.get("_id")
             ctx.sp_id = str(sp_id) if sp_id else None
+
+        # After the context exists and before the MCP server starts: this is the
+        # only point where the id the tools will query is knowable.
+        self._setup_pov_context(ctx.agent_id)
 
     @property
     def system_prompt(self) -> str:
@@ -497,8 +501,18 @@ Start by reading the vulnerable function source: {source_hint}.
 
         return message
 
-    def _setup_pov_context(self) -> None:
-        """Set up POV tools context."""
+    def _setup_pov_context(self, agent_id: str) -> None:
+        """Register the POV tool context under the id the tools look it up by.
+
+        ``agent_id`` must be the ``AgentContext.agent_id`` that
+        :meth:`BaseAgent.run_async` binds the isolated MCP server to. The POV
+        tools resolve their context by that exact key and have no fallback, so
+        registering under anything else makes every one of them answer "POV
+        context not set" for the entire run -- which is why this cannot be
+        called before ``run_async`` creates the context. The seed agent hit the
+        same thing and fixed it the same way; see
+        ``fuzzer/seed_agent.py::_configure_context``.
+        """
         if not self.suspicious_point:
             return
 
@@ -511,7 +525,7 @@ Start by reading the vulnerable function source: {source_hint}.
 
         set_pov_context(
             task_id=self.task_id,
-            worker_id=self.mcp_context_id,  # Use unique ObjectId from AgentContext
+            worker_id=agent_id,  # The id run_async bound the MCP server to
             output_dir=self.output_dir,
             repos=self.repos,
             fuzzer=self.fuzzer,
@@ -522,7 +536,7 @@ Start by reading the vulnerable function source: {source_hint}.
             workspace_path=self.workspace_path,
             fuzzer_source=fuzzer_source,
             fuzzer_manager=self.fuzzer_manager,  # For SP Fuzzer integration
-            agent_id=self.mcp_context_id,  # Track which agent created POVs
+            agent_id=agent_id,  # Track which agent created POVs
         )
 
     def _check_tool_result_for_success(self, tool_name: str, result_str: str) -> bool:
@@ -886,8 +900,8 @@ Call create_pov with a new generator code NOW.""",
         self.successful_pov_id = None
         self.pov_success = False
 
-        # Setup POV context
-        self._setup_pov_context()
+        # The POV context is registered in _configure_context, which run_async
+        # calls once it has minted the agent_id the MCP tools query by.
 
         # Run agent
         try:

--- a/fuzzingbrain/analyzer/server.py
+++ b/fuzzingbrain/analyzer/server.py
@@ -899,6 +899,89 @@ class AnalysisServer:
                     return candidate
         return None
 
+    # Suffixes a harness source actually uses. `.h` is deliberately absent: a
+    # header match would return a declaration where the agent asked for the
+    # entry point.
+    _SOURCE_SUFFIXES = (".cc", ".cpp", ".c", ".cxx", ".c++")
+
+    def _harness_name_candidates(self, fuzzer_name: str) -> List[str]:
+        """The names a harness source might carry, most specific first.
+
+        OSS-Fuzz projects routinely build many named binaries from one source:
+        curl's seventeen harnesses are all ``curl_fuzzer.cc``, picked apart by
+        corpus rather than by source file, so a name-exact search finds none of
+        them. Trailing ``_<segment>`` parts are therefore dropped one at a time
+        -- but only while the remainder still reads as a harness name, or
+        ``curl_fuzzer_ws`` would decay to ``curl`` and match some unrelated
+        ``curl.c``.
+        """
+        candidates = [fuzzer_name]
+        parts = fuzzer_name.split("_")[:-1]
+        while parts:
+            stem = "_".join(parts)
+            if "fuzz" not in stem and "harness" not in stem:
+                break
+            candidates.append(stem)
+            parts = parts[:-1]
+        return candidates
+
+    def _search_fuzzer_source(self, fuzzer_name: str) -> Optional[Path]:
+        """Find a harness source on disk when the build reported none.
+
+        Searched in order of how specific the location is: the scanned repo,
+        the OSS-Fuzz project directory, then the sources a coverage build copies
+        into its output tree -- which is where a harness kept outside the
+        project's own repository ends up.
+        """
+        roots = [self.task_path / "repo"]
+        if self.project_name:
+            roots.append(
+                self.task_path / "fuzz-tooling" / "projects" / self.project_name
+            )
+        if self.coverage_path:
+            roots.append(Path(self.coverage_path))
+
+        for root in roots:
+            if not root.is_dir():
+                continue
+            for stem in self._harness_name_candidates(fuzzer_name):
+                for suffix in self._SOURCE_SUFFIXES:
+                    for hit in sorted(root.rglob(f"{stem}{suffix}")):
+                        if hit.is_file():
+                            # Absolute: the caller hands this back to
+                            # _resolve_source_file as a string, and that only
+                            # understands an absolute path or one relative to
+                            # the workspace -- a path relative to the process's
+                            # cwd resolves to None and the harness reads as
+                            # missing again.
+                            return hit.resolve()
+        return None
+
+    _HEADER_SUFFIXES = (".h", ".hpp", ".hh")
+
+    def _harness_companion_headers(self, sources: List[Path]) -> List[Path]:
+        """Same-stem headers sitting beside a harness source.
+
+        A harness's input format is often declared rather than defined:
+        ``curl_fuzzer.cc`` walks a TLV stream whose type numbers are every one
+        of them a ``#define`` in ``curl_fuzzer.h``. Handed only the ``.cc``, an
+        agent has to infer that table, and on curl-delta-02 it inferred the
+        response slots were consecutive -- 2, 3, 4, 5 -- where they are 2, 17,
+        18, 19. It had the protocol scheme right, the handshake token right and
+        the trigger string right, byte-for-byte; the trigger simply went into
+        the field that means POSTFIELDS, so the connection never reached the
+        state holding the defect, across all eighteen candidates it built.
+        """
+        seen = set()
+        found: List[Path] = []
+        for src in sources:
+            for suffix in self._HEADER_SUFFIXES:
+                header = src.with_suffix(suffix)
+                if header.is_file() and header not in seen:
+                    seen.add(header)
+                    found.append(header)
+        return found
+
     async def _get_fuzzer_source(self, fuzzer_name: str) -> dict:
         """Get fuzzer/harness source code.
 
@@ -961,23 +1044,53 @@ class AnalysisServer:
             except Exception as e:
                 self._log(f"Failed to query fuzzer from DB: {e}", "DEBUG")
 
+        # Priority 4: the filesystem. All three lookups above need the build to
+        # have reported a source path, and none of them fires when a run names
+        # its fuzzers explicitly (`--fuzzers`, or `fuzzers` in a task file):
+        # task_processor creates those records without one. On curl that made
+        # this tool -- the one its own description tells the agent to call
+        # first -- fail on every call, and the agent burned four of its fifty
+        # iterations retrying it.
+        if not source_paths:
+            found = self._search_fuzzer_source(fuzzer_info.name)
+            if found:
+                source_paths.append(str(found))
+                self._log(f"Found harness source on disk: {found}", "DEBUG")
+
         if not source_paths:
             return {
                 "fuzzer": fuzzer_info.name,
-                "error": "Fuzzer source path not available",
+                "error": (
+                    f"No source for harness '{fuzzer_info.name}' is present in "
+                    "this workspace, and no argument will change that -- do not "
+                    "retry. Look for it directly instead: "
+                    'Glob("**/*fuzz*.c*") lists the candidates, Read opens one.'
+                ),
             }
 
         # Read source files
         contents = []
         resolved_paths = []
+        resolved_files: List[Path] = []
         for sp in source_paths:
             source_file = self._resolve_source_file(sp)
             if source_file:
                 try:
                     contents.append(source_file.read_text())
                     resolved_paths.append(sp)
+                    resolved_files.append(source_file)
                 except Exception as e:
                     self._log(f"Failed to read {sp}: {e}", "DEBUG")
+
+        # The header comes with it: see _harness_companion_headers for what
+        # withholding it cost on curl-delta-02.
+        for header in self._harness_companion_headers(resolved_files):
+            try:
+                contents.append(header.read_text())
+                resolved_paths.append(str(header))
+                self._log(f"Including harness header: {header.name}", "DEBUG")
+            except Exception as e:
+                self._log(f"Failed to read header {header}: {e}", "DEBUG")
 
         if not contents:
             return {

--- a/fuzzingbrain/api_server.py
+++ b/fuzzingbrain/api_server.py
@@ -9,6 +9,10 @@ Both share the same business logic.
 from fastapi import FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel
 from typing import Optional, List
+import base64
+from datetime import datetime
+from enum import Enum
+
 from bson import ObjectId
 
 from .core import Task, JobType, ScanMode
@@ -183,6 +187,31 @@ async def start_harness_task(task: Task, targets: List[dict]):
 # =============================================================================
 # API Endpoints
 # =============================================================================
+
+
+def _api_safe(value):
+    """Make a document from ``Model.to_dict()`` serialisable as a response.
+
+    ``to_dict`` exists to be written to MongoDB: it puts a real ``ObjectId`` in
+    ``_id`` and every reference field, and a ``datetime`` in the timestamps.
+    FastAPI can encode neither, so returning one straight from an endpoint is a
+    500 on any non-empty result -- which is what /api/v1/tasks, /api/v1/pov,
+    /api/v1/patch and the status route each did, with the traceback ending in
+    ``TypeError("'ObjectId' object is not iterable")``.
+    """
+    if isinstance(value, ObjectId):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
+    if isinstance(value, dict):
+        return {k: _api_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_api_safe(v) for v in value]
+    return value
 
 
 @app.get("/")
@@ -422,8 +451,8 @@ async def get_status(task_id: str):
             "pov_generated": len(povs),
             "patch_generated": len(patches),
         },
-        povs=[p.to_dict() for p in povs[:10]],  # Return max 10
-        patches=[p.to_dict() for p in patches[:10]],
+        povs=[_api_safe(p.to_dict()) for p in povs[:10]],  # Return max 10
+        patches=[_api_safe(p.to_dict()) for p in patches[:10]],
         error=task.error_msg,
     )
 
@@ -449,7 +478,7 @@ async def list_tasks(
     tasks = repos.tasks.find_all(query, limit=limit)
 
     return {
-        "tasks": [t.to_dict() for t in tasks],
+        "tasks": [_api_safe(t.to_dict()) for t in tasks],
         "total": len(tasks),
     }
 
@@ -476,7 +505,7 @@ async def get_povs(task_id: str, active_only: bool = True):
 
     return {
         "task_id": task_id,
-        "povs": [p.to_dict() for p in povs],
+        "povs": [_api_safe(p.to_dict()) for p in povs],
         "total": len(povs),
     }
 
@@ -498,7 +527,7 @@ async def get_patches(task_id: str, valid_only: bool = False):
 
     return {
         "task_id": task_id,
-        "patches": [p.to_dict() for p in patches],
+        "patches": [_api_safe(p.to_dict()) for p in patches],
         "total": len(patches),
     }
 

--- a/fuzzingbrain/core/config.py
+++ b/fuzzingbrain/core/config.py
@@ -148,6 +148,18 @@ class Config:
 
         return cls(
             workspace=data.get("workspace"),
+            task_id=data.get("task_id"),
+            in_place=bool(data.get("in_place", False)),
+            # Evaluation posture. These were reachable only from the command
+            # line and the environment, so a task file -- the form a challenge
+            # run is actually written in -- could not express them, and a
+            # `"remove_git": true` in one was read by nothing and reported by
+            # nothing. A flag or environment variable can still turn them on
+            # over a task file that leaves them off; neither can turn them off.
+            remove_git=bool(data.get("remove_git", False)),
+            no_network=bool(data.get("no_network", False)),
+            enable_static_analysis=bool(data.get("enable_static_analysis", False)),
+            allow_expensive_fallback=bool(data.get("allow_expensive_fallback", False)),
             task_type=data.get("task_type", "pov"),
             scan_mode=data.get("scan_mode", "full"),
             sanitizers=data.get("sanitizers", ["address"]),

--- a/fuzzingbrain/core/task_processor.py
+++ b/fuzzingbrain/core/task_processor.py
@@ -22,7 +22,11 @@ from bson import ObjectId
 
 from .logging import logger, create_final_summary, WorkerColors, get_log_dir
 from .config import Config
-from .workspace_guard import assert_workspace_clean
+from .workspace_guard import (
+    assert_workspace_clean,
+    format_banner,
+    sanitize_workspace,
+)
 from .models import Task, TaskStatus, Fuzzer, FuzzerStatus
 from ..db import RepositoryManager
 
@@ -805,13 +809,37 @@ class TaskProcessor:
                     logger.info(f"Found {len(fuzzers)} fuzzers")
                     fuzzer_discovery.save_fuzzers(fuzzers)
 
-            # Before building anything, refuse to proceed if the workspace still
-            # holds the answer. Sanitisation happens in setup_workspace; this is
-            # the assertion that a future change cannot silently skip. It raises
-            # rather than warns on purpose -- a run that looks successful while
-            # its findings are worthless is the exact failure being prevented.
+            # Sanitisation belongs here rather than at any one entry point,
+            # because this pipeline is what every entry point funnels through:
+            # the shell wrapper's plain-URL and flag forms, a JSON task file,
+            # the REST API, the MCP server. Wiring it into a single entry point
+            # covered the JSON form and silently left the plain-URL form -- the
+            # first example in the README -- running against a workspace that
+            # still held its own answer. It sits after Step 3.5 so a delta run's
+            # diff already exists, and before the build so nothing is compiled
+            # from a tree that has not been cleaned.
+            task_path = Path(task.task_path)
+            diff_ready = (task_path / "diff" / "ref.diff").exists()
+            report = sanitize_workspace(
+                task_path,
+                remove_git=self.config.remove_git,
+                diff_ready=diff_ready if self.config.scan_mode == "delta" else True,
+            )
+            logger.info("Workspace posture")
+            for line in format_banner(
+                report,
+                remove_git=self.config.remove_git,
+                network_blocked=self.config.no_network,
+                confined_to=f"{task_path.name}/repo",
+            ):
+                logger.info(line)
+
+            # Then refuse to proceed if anything survived. This raises rather
+            # than warns on purpose -- a run that looks successful while its
+            # findings are worthless is the exact failure being prevented, and
+            # it is what caught the gap described above.
             assert_workspace_clean(
-                Path(task.task_path),
+                task_path,
                 require_no_git=self.config.remove_git,
             )
 

--- a/fuzzingbrain/core/workspace_guard.py
+++ b/fuzzingbrain/core/workspace_guard.py
@@ -19,9 +19,13 @@ remembered by every present and future tool while a missing directory does not.
 but it costs the ability to regenerate a delta diff in that workspace -- so it
 is a switch, and it refuses to run before the diff exists.
 
-Sanitisation runs on the Python side only. Every entry point -- the shell
-wrapper, the API server, a direct ``python -m fuzzingbrain.main`` -- ends up in
-:func:`fuzzingbrain.main.setup_workspace`, so one call site covers all of them.
+Sanitisation runs on the Python side only, from
+:func:`fuzzingbrain.core.task_processor.TaskProcessor.process`. That is the one
+place every entry point reaches -- the shell wrapper's plain-URL and flag forms,
+a JSON task file, the REST API, the MCP server. An earlier version called it
+from ``main.setup_workspace`` instead, which serves the JSON form alone, so
+``./FuzzingBrain.sh <git_url>`` built against a tree that still held its own
+answer until :func:`assert_workspace_clean` stopped the run.
 """
 
 import shutil

--- a/fuzzingbrain/fuzzer/seed_tools.py
+++ b/fuzzingbrain/fuzzer/seed_tools.py
@@ -198,7 +198,11 @@ def _ensure_context(worker_id: str = None) -> Optional[Dict[str, Any]]:
     if ctx is None or ctx.get("task_id") is None:
         return {
             "success": False,
-            "error": "Seed context not set. Call set_seed_context first.",
+            "error": (
+                "The seed tools are not initialised for this agent. This is a "
+                "fault in the run's setup, not in your arguments -- retrying "
+                "will not help. Report your analysis instead."
+            ),
         }
     return None
 

--- a/fuzzingbrain/main.py
+++ b/fuzzingbrain/main.py
@@ -29,7 +29,6 @@ from .core import (
     setup_celery_logging,
     setup_console_only,
 )
-from .core.workspace_guard import format_banner, sanitize_workspace
 from .db import MongoDB, RepositoryManager, init_repos
 
 
@@ -1032,24 +1031,10 @@ def setup_workspace(config: Config) -> Config:
             except Exception as e:
                 print_warn(f"Failed to generate diff: {e}")
 
-    # Sanitise the workspace here, after the checkout and after the diff: every
-    # entry point funnels through this function -- the shell wrapper, the API
-    # server and a direct module invocation alike -- so one call covers them all.
-    diff_ready = (workspace / "diff" / "ref.diff").exists()
-    report = sanitize_workspace(
-        workspace,
-        remove_git=config.remove_git,
-        diff_ready=diff_ready if config.scan_mode == "delta" else True,
-    )
-    print_step("Workspace posture")
-    for line in format_banner(
-        report,
-        remove_git=config.remove_git,
-        network_blocked=config.no_network,
-        confined_to=f"{workspace.name}/repo",
-    ):
-        print_info(line)
-
+    # Sanitisation is deliberately not done here. This function serves the JSON
+    # entry point only, and cleaning the workspace from an entry point is what
+    # left the other entry points uncleaned. It happens in
+    # core.task_processor.process, which every entry point reaches.
     return config
 
 

--- a/fuzzingbrain/tools/pov.py
+++ b/fuzzingbrain/tools/pov.py
@@ -282,12 +282,22 @@ def _ensure_context(worker_id: str = None) -> Optional[Dict[str, Any]]:
     if ctx is None or ctx.get("task_id") is None:
         return {
             "success": False,
-            "error": "POV context not set. Call set_pov_context first.",
+            "error": (
+                "The POV tools are not initialised for this agent. This is a "
+                "fault in the run's setup, not in your arguments, and no "
+                "argument you pass will change it -- retrying wastes the "
+                "budget. Stop calling the POV tools and report your analysis "
+                "of the suspicious point instead."
+            ),
         }
     if ctx.get("repos") is None:
         return {
             "success": False,
-            "error": "Database repos not available in POV context.",
+            "error": (
+                "The POV tools have no database connection. This is a fault in "
+                "the run's setup, not in your arguments -- retrying will not "
+                "help. Report your analysis instead."
+            ),
         }
     return None
 

--- a/fuzzingbrain/worker/strategies/pov_delta.py
+++ b/fuzzingbrain/worker/strategies/pov_delta.py
@@ -66,8 +66,16 @@ class POVDeltaStrategy(POVBaseStrategy):
             task_id=self.task_id,
             worker_id=self.worker_id,
             log_dir=agent_log_dir,
-            max_iterations=50,  # Need more iterations for finding SPs in delta mode
+            max_iterations=self.SP_ITERATIONS_WITH_INDEX,
         )
+
+    # Iteration budgets for the delta SP generator. The first is enough when the
+    # diff arrives already mapped to named functions -- the agent starts from a
+    # short worklist. The second covers reading an unmapped diff before any
+    # judgement can begin, which is a different job: 17 files and 933 lines on
+    # curl-delta-02.
+    SP_ITERATIONS_WITH_INDEX = 50
+    SP_ITERATIONS_NO_INDEX = 150
 
     @property
     def strategy_name(self) -> str:
@@ -211,6 +219,21 @@ class POVDeltaStrategy(POVBaseStrategy):
         self.log_info(
             f"Passing {len(all_changes)} functions to agent ({reachable_count} reachable, {len(all_changes) - reachable_count} static-unreachable)"
         )
+
+        # An agent given a list of changed functions starts from a short, named
+        # worklist. An agent given only the raw diff has to build that list
+        # itself with Glob, Grep and Read before it can judge anything, and the
+        # budget that covers the first is spent on navigation in the second: on
+        # curl-delta-02 the agent made 51 tool calls, hit the cap of 50
+        # iterations still exploring, and recorded no suspicious point at all.
+        # The budget follows the work rather than the scan mode.
+        if not all_changes:
+            self._sp_generator.max_iterations = self.SP_ITERATIONS_NO_INDEX
+            self.log_info(
+                "No function list for this diff, so the agent has to map it "
+                f"itself -- raising its iteration budget to "
+                f"{self.SP_ITERATIONS_NO_INDEX}"
+            )
 
         # Run the generator to find suspicious points
         try:

--- a/tests/test_config_json_posture.py
+++ b/tests/test_config_json_posture.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A task file has to be able to express the run's posture.
+
+The anti-cheat switches, the call-graph switch and the expensive-model switch
+were reachable only from the command line and the environment. A JSON task
+file -- the form an AIxCC challenge run is actually written in -- could not set
+them: `"remove_git": true` in one was read by nothing, warned about by nothing,
+and left the run using the default.
+"""
+
+import json
+
+import pytest
+
+from fuzzingbrain.core.config import Config
+
+POSTURE = [
+    "remove_git",
+    "no_network",
+    "enable_static_analysis",
+    "allow_expensive_fallback",
+    "in_place",
+]
+
+
+def _cfg(tmp_path, **extra):
+    data = {"repo_url": "https://example.invalid/x.git", "project_name": "curl"}
+    data.update(extra)
+    path = tmp_path / "task.json"
+    path.write_text(json.dumps(data))
+    return Config.from_json(str(path))
+
+
+@pytest.mark.parametrize("field", POSTURE)
+def test_a_task_file_can_turn_each_switch_on(tmp_path, field):
+    assert getattr(_cfg(tmp_path, **{field: True}), field) is True
+
+
+@pytest.mark.parametrize("field", POSTURE)
+def test_each_switch_stays_off_when_the_task_file_omits_it(tmp_path, field):
+    assert getattr(_cfg(tmp_path), field) is False
+
+
+def test_a_task_file_can_name_the_task_id(tmp_path):
+    """Reusing a workspace across runs needs the same task id."""
+    tid = "6a906f8f0c63f464e5efa7fb"
+    assert _cfg(tmp_path, task_id=tid).task_id == tid
+
+
+def test_the_task_id_is_none_when_unset(tmp_path):
+    assert _cfg(tmp_path).task_id is None
+
+
+def test_the_challenge_example_asks_for_history_removal():
+    """The example exists to show a run that cannot cheat, and `git show
+    <ref>:.aixcc/...` recovers the answer from history the working tree no
+    longer has."""
+    data = json.loads(open("examples/07_aixcc_challenge/cu-delta-02.json").read())
+    assert data["remove_git"] is True
+
+
+def test_the_challenge_example_names_the_harness_header():
+    """curl's TLV type numbers live in curl_fuzzer.h, not curl_fuzzer.cc."""
+    data = json.loads(open("examples/07_aixcc_challenge/cu-delta-02.json").read())
+    sources = data["fuzzer_sources"]["curl_fuzzer_ws"]
+    assert any(p.endswith(".cc") for p in sources)
+    assert any(p.endswith(".h") for p in sources)

--- a/tests/test_delta_degrades_without_index.py
+++ b/tests/test_delta_degrades_without_index.py
@@ -105,3 +105,43 @@ def test_seed_agent_tolerates_an_empty_change_list():
 
     src = inspect.getsource(seed_agent)
     assert "if changed_functions:" in src
+
+
+# --------------------------------------------- the budget follows the work
+#
+# Degrading to the raw diff made the scan possible; it did not make it
+# affordable. On curl-delta-02 the agent made 51 tool calls mapping a 17-file
+# diff by hand, hit the cap of 50 iterations still exploring, and recorded no
+# suspicious point -- while 97% of the run's dollar budget went unspent. The
+# binding constraint was the iteration count, not the money.
+
+
+def test_an_unmapped_diff_gets_the_larger_budget():
+    from fuzzingbrain.worker.strategies.pov_delta import POVDeltaStrategy
+
+    assert (
+        POVDeltaStrategy.SP_ITERATIONS_NO_INDEX
+        > POVDeltaStrategy.SP_ITERATIONS_WITH_INDEX
+    )
+
+
+def test_the_generator_starts_on_the_mapped_budget():
+    """Raising it is a decision made when the diff turns out to be unmapped,
+    not the default for every delta scan."""
+    import inspect
+
+    from fuzzingbrain.worker.strategies import pov_delta
+
+    src = inspect.getsource(pov_delta.POVDeltaStrategy)
+    assert "max_iterations=self.SP_ITERATIONS_WITH_INDEX" in src
+    assert "max_iterations = self.SP_ITERATIONS_NO_INDEX" in src
+
+
+def test_the_raise_is_conditioned_on_having_no_function_list():
+    import inspect
+
+    from fuzzingbrain.worker.strategies import pov_delta
+
+    src = inspect.getsource(pov_delta.POVDeltaStrategy)
+    i = src.index("max_iterations = self.SP_ITERATIONS_NO_INDEX")
+    assert "if not all_changes:" in src[max(0, i - 400) : i]

--- a/tests/test_harness_source_fallback.py
+++ b/tests/test_harness_source_fallback.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+"""get_fuzzer_source must find the harness, or say so usefully.
+
+Its own description tells the agent this is the most important tool and to call
+it first. On the curl challenge it failed on all four calls with "Fuzzer source
+path not available": every lookup it had needed the build to report a source
+path, and none of them fires when a run names its fuzzers explicitly. The agent
+retried it four times out of fifty iterations and found no suspicious points.
+"""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from fuzzingbrain.analyzer.server import AnalysisServer
+
+
+def _server(task_path, project_name="curl", coverage_path=None):
+    """A server object with only the attributes the lookup touches."""
+    srv = AnalysisServer.__new__(AnalysisServer)
+    srv.task_path = Path(task_path)
+    srv.project_name = project_name
+    srv.coverage_path = str(coverage_path) if coverage_path else None
+    return srv
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Shaped like the curl challenge: the harness lives outside the repo, and
+    only the coverage build leaves a copy of it on disk."""
+    ws = tmp_path / "curl_task"
+    (ws / "repo" / "lib").mkdir(parents=True)
+    (ws / "repo" / "lib" / "ws.c").write_text("/* not a harness */\n")
+
+    proj = ws / "fuzz-tooling" / "projects" / "curl"
+    proj.mkdir(parents=True)
+    (proj / "curl_fuzzer_ws.options").write_text("[libfuzzer]\n")
+
+    cov = ws / "fuzz-tooling" / "build" / "out" / "curl_coverage"
+    src = cov / "src" / "curl_fuzzer"
+    src.mkdir(parents=True)
+    (src / "curl_fuzzer.cc").write_text("int LLVMFuzzerTestOneInput(){return 0;}\n")
+    (src / "curl_fuzzer.h").write_text("void decl(void);\n")
+    (src / "fuzz_url.cc").write_text("int LLVMFuzzerTestOneInput(){return 1;}\n")
+    return ws, cov
+
+
+# ------------------------------------------------------------ name candidates
+
+
+def test_a_variant_name_falls_back_to_its_base():
+    """curl builds seventeen named binaries from one curl_fuzzer.cc."""
+    srv = _server("/nowhere")
+    assert srv._harness_name_candidates("curl_fuzzer_ws") == [
+        "curl_fuzzer_ws",
+        "curl_fuzzer",
+    ]
+
+
+def test_stripping_stops_before_the_name_stops_being_a_harness():
+    """Otherwise curl_fuzzer_ws decays to 'curl' and matches any curl.c."""
+    assert "curl" not in _server("/nowhere")._harness_name_candidates("curl_fuzzer_ws")
+
+
+def test_a_name_with_nothing_to_strip_is_tried_once():
+    srv = _server("/nowhere")
+    assert srv._harness_name_candidates("libpng_read_fuzzer") == ["libpng_read_fuzzer"]
+
+
+# ------------------------------------------------------------------- searching
+
+
+def test_the_coverage_tree_is_searched_when_the_repo_has_no_harness(workspace):
+    ws, cov = workspace
+    hit = _server(ws, coverage_path=cov)._search_fuzzer_source("curl_fuzzer_ws")
+    assert hit is not None and hit.name == "curl_fuzzer.cc"
+
+
+def test_a_harness_with_its_own_file_is_not_collapsed(workspace):
+    ws, cov = workspace
+    hit = _server(ws, coverage_path=cov)._search_fuzzer_source("fuzz_url")
+    assert hit is not None and hit.name == "fuzz_url.cc"
+
+
+def test_a_header_is_never_the_answer(workspace):
+    ws, cov = workspace
+    hit = _server(ws, coverage_path=cov)._search_fuzzer_source("curl_fuzzer")
+    assert hit is not None and hit.suffix != ".h"
+
+
+def test_the_repo_wins_over_the_coverage_tree(workspace):
+    """A harness kept in the scanned repo is the one being scanned."""
+    ws, cov = workspace
+    (ws / "repo" / "contrib").mkdir()
+    own = ws / "repo" / "contrib" / "curl_fuzzer.cc"
+    own.write_text("int LLVMFuzzerTestOneInput(){return 2;}\n")
+    hit = _server(ws, coverage_path=cov)._search_fuzzer_source("curl_fuzzer_ws")
+    assert hit == own
+
+
+def test_nothing_on_disk_returns_none(workspace):
+    ws, cov = workspace
+    assert _server(ws, coverage_path=cov)._search_fuzzer_source("gzip_fuzzer") is None
+
+
+def test_a_missing_coverage_build_is_not_an_error(workspace):
+    ws, _ = workspace
+    assert _server(ws, coverage_path=None)._search_fuzzer_source("curl_fuzzer") is None
+
+
+# --------------------------------------------------------------- the message
+
+
+class _Fuzzer:
+    def __init__(self, name):
+        self.name = name
+        self.source_path = None
+
+
+def _lookup(ws, cov, name):
+    srv = _server(ws, coverage_path=cov)
+    srv.fuzzers = [_Fuzzer(name)]
+    srv.fuzzer_sources = {}
+    srv.repos = None
+    srv._log = lambda *a, **k: None
+    return asyncio.run(srv._get_fuzzer_source(name))
+
+
+def test_a_found_harness_comes_back_with_its_source(workspace):
+    ws, cov = workspace
+    result = _lookup(ws, cov, "curl_fuzzer_ws")
+    assert "error" not in result
+    assert "LLVMFuzzerTestOneInput" in result["source"]
+
+
+def test_the_failure_tells_the_agent_what_to_do_instead(workspace):
+    """The old text named neither a cause nor a next step, so the model's only
+    move was to call it again."""
+    ws, cov = workspace
+    err = _lookup(ws, cov, "gzip_fuzzer")["error"]
+    assert "do not" in err.lower() and "retry" in err.lower()
+    assert "Glob(" in err and "Read" in err
+
+
+# ------------------------------------------------- the header comes with it
+#
+# curl-delta-02, second attempt: the agent found the right function, learned
+# the harness's TLV wire format, used the invented protocol scheme and put the
+# exact trigger string -- CRLF included -- in seventeen of eighteen candidates.
+# None crashed. The TLV type numbers are all #defines in curl_fuzzer.h, which
+# get_fuzzer_source did not return, so it inferred the response slots were
+# consecutive (2, 3, 4, 5) where they are 2, 17, 18, 19. Every trigger landed
+# in the field that means POSTFIELDS.
+
+
+def test_the_same_stem_header_is_returned_with_the_source(workspace):
+    ws, cov = workspace
+    result = _lookup(ws, cov, "curl_fuzzer_ws")
+    assert isinstance(result["source_path"], list)
+    assert any(p.endswith("curl_fuzzer.h") for p in result["source_path"])
+    assert "void decl(void);" in result["source"], "header content, not just its name"
+
+
+def test_the_source_still_comes_first(workspace):
+    """The entry point is what the agent reads first; the header supports it."""
+    ws, cov = workspace
+    src = _lookup(ws, cov, "curl_fuzzer_ws")["source"]
+    assert src.index("LLVMFuzzerTestOneInput") < src.index("void decl(void);")
+
+
+def test_an_unrelated_header_is_not_dragged_in(workspace):
+    ws, cov = workspace
+    (cov / "src" / "curl_fuzzer" / "unrelated.h").write_text("#define NOPE 1\n")
+    assert "NOPE" not in _lookup(ws, cov, "curl_fuzzer_ws")["source"]
+
+
+def test_a_harness_without_a_header_is_unaffected(workspace):
+    ws, cov = workspace
+    result = _lookup(ws, cov, "fuzz_url")
+    assert "error" not in result
+    assert isinstance(result["source_path"], str), "one file, reported as one"
+
+
+def test_the_fallback_returns_an_absolute_path(workspace):
+    """_resolve_source_file only understands an absolute path or one relative
+    to the workspace; a cwd-relative path resolves to None and the harness
+    reads as missing all over again."""
+    ws, cov = workspace
+    hit = _server(ws, coverage_path=cov)._search_fuzzer_source("curl_fuzzer_ws")
+    assert hit is not None and hit.is_absolute()

--- a/tests/test_pov_context_key.py
+++ b/tests/test_pov_context_key.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The POV tool context must be registered under the id the tools query by.
+
+``BaseAgent.run_async`` mints an ``AgentContext.agent_id`` and binds the
+isolated MCP server to it. The POV tools resolve their context by that exact
+key, with no fallback, so registering under any other id makes every POV tool
+answer "not initialised" for the whole run -- which is what happened: the setup
+ran before ``run_async`` existed to mint the id, so it landed under
+``self.worker_id`` and the two keys were consecutive ObjectIds that never met.
+"""
+
+import pytest
+
+from fuzzingbrain.agents.pov_agent import POVAgent
+from fuzzingbrain.tools import pov as P
+
+STORE_KEY = "6a8ffc48b36d5447f576188e"  # what worker_id was, in the failing run
+LOOKUP_KEY = "6a8ffc48b36d5447f576188f"  # what ctx.agent_id was: one digit apart
+
+
+class _Ctx:
+    """Stands in for AgentContext: the agent only reads agent_id and sets sp_id."""
+
+    def __init__(self, agent_id):
+        self.agent_id = agent_id
+        self.sp_id = None
+
+
+@pytest.fixture
+def agent():
+    with P._pov_contexts_lock:
+        P._pov_contexts.clear()
+    a = POVAgent(
+        fuzzer="libpng_read_fuzzer",
+        task_id="3aa25c01736d484da8d6374b",
+        worker_id=STORE_KEY,
+        repos=object(),  # only stored, never called here
+        fuzzer_code="int LLVMFuzzerTestOneInput(const uint8_t *d, size_t n){return 0;}",
+        verbose=False,
+    )
+    a.suspicious_point = {"_id": "6a8ffc66699de4c4", "function_name": "png_handle_iCCP"}
+    yield a
+    with P._pov_contexts_lock:
+        P._pov_contexts.clear()
+
+
+def test_context_is_registered_under_the_agent_id(agent):
+    agent._configure_context(_Ctx(LOOKUP_KEY))
+    assert P._get_context_by_worker_id(LOOKUP_KEY) is not None
+    assert P._ensure_context(worker_id=LOOKUP_KEY) is None, "tools must be usable"
+
+
+def test_the_worker_id_is_not_the_key(agent):
+    """The regression itself: registering under worker_id is what broke create_pov."""
+    agent._configure_context(_Ctx(LOOKUP_KEY))
+    assert P._get_context_by_worker_id(STORE_KEY) is None
+
+
+def test_setup_cannot_run_before_the_context_exists(agent):
+    """Why the call sits in _configure_context and not before run_async."""
+    assert agent.mcp_context_id == STORE_KEY, "no context yet: falls back to worker_id"
+    assert agent.mcp_context_id != LOOKUP_KEY
+
+
+def test_sp_id_is_still_configured(agent):
+    ctx = _Ctx(LOOKUP_KEY)
+    agent._configure_context(ctx)
+    assert ctx.sp_id == "6a8ffc66699de4c4"
+
+
+def test_no_suspicious_point_registers_nothing(agent):
+    agent.suspicious_point = None
+    agent._configure_context(_Ctx(LOOKUP_KEY))
+    assert P._get_context_by_worker_id(LOOKUP_KEY) is None
+
+
+def test_uninitialised_tools_do_not_name_a_tool_the_agent_lacks():
+    """The old text said "Call set_pov_context first" -- not a tool the agent
+    has. A model told to call something unavailable can only retry, which is
+    how one agent spent 100 iterations and 462s on 47 identical failures."""
+    err = P._ensure_context(worker_id="unregistered")["error"]
+    assert "set_pov_context" not in err
+    assert "retrying" in err.lower()

--- a/tests/test_static_analysis_gating.py
+++ b/tests/test_static_analysis_gating.py
@@ -231,3 +231,119 @@ def test_agent_filters_do_not_use_allow_lists():
     for cls in (SPGeneratorBase, SPVerifier):
         src = inspect.getsource(cls._filter_tools_for_mode)
         assert "not in" in src, f"{cls.__name__} filters by exclusion, not inclusion"
+
+
+# ------------------------------------------------------- deciding the gates
+#
+# Everything above passes the gate booleans in directly, so it tests the gate
+# and never the code that decides it. That is where a wrong import name sat
+# unnoticed: _analysis_status asked for AnalyzerClient, the class is called
+# AnalysisClient, and the except branch quietly reported every tool group as
+# available. The gates shipped as a no-op and the suite stayed green.
+
+
+class _StatusProbe:
+    """Exercises _analysis_status without constructing a real agent."""
+
+    from fuzzingbrain.agents.base import BaseAgent
+
+    _analysis_status = BaseAgent._analysis_status
+    include_static_analysis_tools = BaseAgent.include_static_analysis_tools
+    include_coverage_tools = BaseAgent.include_coverage_tools
+
+    def __init__(self):
+        self.logged = []
+
+    def _log(self, message, level="INFO"):
+        self.logged.append(message)
+
+
+def _probe_with(monkeypatch, reply):
+    from fuzzingbrain.tools import analyzer as A
+
+    monkeypatch.setattr(A, "analyzer_status", lambda: reply)
+    return _StatusProbe()
+
+
+def test_the_status_call_resolves_against_the_real_client():
+    """The regression: the name the agent imports has to exist."""
+    from fuzzingbrain.tools.analyzer import analyzer_status
+
+    assert callable(analyzer_status)
+
+
+def test_an_unreachable_server_reports_the_server_not_a_typo(monkeypatch):
+    """With no analyzer socket set the read fails -- and the reason logged must
+    be the server being absent, not a wrong name inside this module."""
+    probe = _StatusProbe()
+    assert probe._analysis_status() == {}
+    reason = " ".join(probe.logged)
+    assert "cannot import name" not in reason
+    assert "AnalyzerClient" not in reason
+
+
+def test_a_failed_read_closes_the_index_gate_and_leaves_coverage_open():
+    """The two gates read an empty status in opposite directions on purpose:
+    the index tools use the socket that just failed, the coverage tools do
+    not."""
+    probe = _StatusProbe()
+    assert probe.include_static_analysis_tools is False
+    assert probe.include_coverage_tools is True
+
+
+def test_an_index_and_a_coverage_build_open_both_gates(monkeypatch):
+    probe = _probe_with(
+        monkeypatch,
+        {
+            "success": True,
+            "status": {"function_count": 399, "coverage_available": True},
+        },
+    )
+    assert probe.include_static_analysis_tools is True
+    assert probe.include_coverage_tools is True
+
+
+def test_an_empty_index_closes_the_index_gate(monkeypatch):
+    probe = _probe_with(
+        monkeypatch,
+        {"success": True, "status": {"function_count": 0, "coverage_available": True}},
+    )
+    assert probe.include_static_analysis_tools is False
+    assert probe.include_coverage_tools is True
+
+
+def test_a_missing_coverage_build_closes_only_the_coverage_gate(monkeypatch):
+    probe = _probe_with(
+        monkeypatch,
+        {
+            "success": True,
+            "status": {"function_count": 399, "coverage_available": False},
+        },
+    )
+    assert probe.include_static_analysis_tools is True
+    assert probe.include_coverage_tools is False
+
+
+def test_a_failed_reply_is_logged_with_the_servers_own_reason(monkeypatch):
+    probe = _probe_with(monkeypatch, {"success": False, "error": "socket not set"})
+    assert probe._analysis_status() == {}
+    assert probe.include_static_analysis_tools is False
+    assert probe.include_coverage_tools is True
+    assert "socket not set" in " ".join(probe.logged)
+
+
+def test_the_status_is_fetched_once_per_agent(monkeypatch):
+    from fuzzingbrain.tools import analyzer as A
+
+    calls = []
+
+    def counting():
+        calls.append(1)
+        return {"success": True, "status": {"function_count": 1}}
+
+    monkeypatch.setattr(A, "analyzer_status", counting)
+    probe = _StatusProbe()
+    probe.include_static_analysis_tools
+    probe.include_coverage_tools
+    probe._analysis_status()
+    assert len(calls) == 1

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -432,9 +432,11 @@ def generate(seed_num: int) -> bytes:
             worker_id=nonexistent_worker_id,
         )
 
-        # Should fail with "context not set" error
+        # The message must say the setup is at fault and retrying is pointless,
+        # without naming set_seed_context -- not a tool the agent has.
         assert result["success"] is False
-        assert "context not set" in result["error"].lower()
+        assert "not initialised" in result["error"]
+        assert "set_seed_context" not in result["error"]
 
     def test_mcp_factory_registers_seed_tools_with_worker_id(self):
         """MCP factory should register seed tools with worker_id bound in closure."""

--- a/tests/test_workspace_guard.py
+++ b/tests/test_workspace_guard.py
@@ -177,3 +177,42 @@ def test_builder_copies_exclude_answers_and_history(workspace, tmp_path):
     assert (dest / "pngrutil.c").exists()
     assert not (dest / ".aixcc").exists()
     assert not (dest / ".git").exists()
+
+
+# ------------------------------------------------------- where it is called
+#
+# The tests above prove sanitisation works when it runs. They said nothing
+# about whether it runs, and it did not: the call lived in
+# main.setup_workspace, which serves the JSON entry point alone, so
+# `./FuzzingBrain.sh <git_url>` -- the first example in the README -- reached
+# the build with .aixcc still in the tree. assert_workspace_clean caught it and
+# aborted the run, which is the design working, but the example was dead.
+
+
+def _source(module_path):
+    import pathlib
+
+    return pathlib.Path(module_path).read_text()
+
+
+def test_sanitisation_runs_from_the_shared_pipeline():
+    """Not from an entry point: the pipeline is what every entry point reaches
+    (plain URL, flags, JSON file, REST API, MCP server)."""
+    src = _source("fuzzingbrain/core/task_processor.py")
+    assert "sanitize_workspace(" in src
+
+
+def test_sanitisation_precedes_the_assertion():
+    """Cleaning after the check would make the check meaningless."""
+    src = _source("fuzzingbrain/core/task_processor.py")
+    assert src.index("sanitize_workspace(") < src.index("assert_workspace_clean(")
+
+
+def test_no_entry_point_sanitises_on_its_own():
+    """One call site, or the next entry point added quietly skips it."""
+    assert "sanitize_workspace(" not in _source("fuzzingbrain/main.py")
+
+
+def test_the_posture_is_reported_where_it_is_enforced():
+    """A run has to be able to prove from its log what was enforced."""
+    assert "format_banner(" in _source("fuzzingbrain/core/task_processor.py")


### PR DESCRIPTION
Nine defects found by running the system against a real AIxCC challenge rather than by reading it. None of them is in the reasoning; every one is a place where the tool layer withheld information or reported success it did not have.

## What the run showed

`cu-delta-02` — a CWE-476 NULL dereference the challenge places at `lib/totallyfineprotocl.c:228-232`, reachable only through `curl_fuzzer_ws`, triggered by the server writing a specific response mid-connection. Three runs:

| | SP | Candidates | Crashes | Stopped by |
|---|---|---|---|---|
| 1 | 0 | — | — | `max_iterations=50` spent on exploration |
| 2 | 1 | 60 | 0 | no `curl_fuzzer.h`, so the TLV response slots were guessed as 3/4/5 |
| 3 | 1 | 1 | **1** | found on iteration 4 |

Run 2's candidates had the invented protocol scheme, the handshake token and the trigger string right to the byte, CRLF included. They put the trigger in the field that means POSTFIELDS. The type table is `#define`s in a header `get_fuzzer_source` did not return.

Run 3, verified against the challenge's own answer:

```
SUMMARY: AddressSanitizer: SEGV /src/curl/lib/totallyfineprotocl.c:232:33
         in totallyfineprotocl_sm
```

14.6 minutes, $2.14 of a $20 cap. Same model, same challenge, same code — the only change is that a constant table reached the context.

## Fixes

- **POV tool context** registered under `worker_id` while the MCP server was bound to a fresh `AgentContext.agent_id` — consecutive ObjectIds, `...188e` stored and `...188f` read. 97 `create_pov` calls across the logs, none successful. The seed agent fixed this months ago; POV never got the same change.
- **`AnalyzerClient`** does not exist — the class is `AnalysisClient`. Every gate check raised and took the except branch, so the index and coverage gates shipped as a no-op.
- **`get_fuzzer_source`** had no lookup that works when a run names its fuzzers explicitly. It now falls back to the filesystem and returns the harness's header alongside its source.
- **Workspace sanitisation** ran from the JSON entry point only, so `./FuzzingBrain.sh <git_url>` reached the build with `.aixcc` in the tree. Moved to the pipeline every entry point passes through.
- **Delta SP iteration budget** is now sized to whether the diff arrived mapped.
- **Five API endpoints** returned MongoDB documents to FastAPI: a 500 on any non-empty result.
- **Task files** can now express `remove_git`, `no_network`, `enable_static_analysis` and three more, which were flag-only.
- **Error messages** that named tools the agent does not have, leaving retry as its only move.

## README

Every runnable example targeted a libpng fork that does not build — OSS-Fuzz's libpng recipe copies `build.sh` out of `pnggroup/libpng@master`, so upstream tooling compiles a harness the pinned commit lacks. Replaced with one example: a fully pinned challenge, invoked as `./FuzzingBrain.sh examples/07_aixcc_challenge/cu-delta-02.json`, with its expected result written down. Also corrected the Python badge (3.10 → 3.11, which the dependencies require) and a pointer to prebuilt call graphs that are not in the repository.

## Tests

601 → 652. Each addition covers a case that actually failed; the POV context test was checked against the pre-fix code and fails there.

Untouched: `examples/aixcc-challenges/` and `.gitattributes`, which are another branch's in-flight work.