### PR TITLE
README: --help does not set the environment up

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ git clone https://github.com/fuzzingbrain/afc-crs-all-you-need-is-a-fuzzing-brai
 cd afc-crs-all-you-need-is-a-fuzzing-brain
 
 cp .env.example .env
-$EDITOR .env                  # add at least one API key
-
-./FuzzingBrain.sh --help      # bootstraps uv, venv, deps, MongoDB, Redis
+$EDITOR .env          # add at least one API key
 ```
+
+The first run installs `uv`, builds `venv/` on Python 3.11, installs
+`requirements.txt` and starts the MongoDB and Redis containers. `--help` prints
+options without doing any of that.
 
 ## Run an example
 


### PR DESCRIPTION
Verified in a fresh clone: `./FuzzingBrain.sh --help` leaves no `.uv/`, no `venv/`, no installed dependencies. It exits at show_usage, before the environment checks. The bootstrap happens on the first real run.